### PR TITLE
fix: P0 credibility fixes — doc contradictions, benchmark fairness, 7…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Live Arena](https://img.shields.io/badge/Live_Arena-Run_Benchmarks-blue?style=for-the-badge)](https://revred.github.io/Sharc/)
 [![NuGet](https://img.shields.io/nuget/v/Sharc.svg?style=for-the-badge)](https://www.nuget.org/packages/Sharc/)
-[![Tests](https://img.shields.io/badge/tests-1%2C646_passing-brightgreen?style=for-the-badge)]()
+[![Tests](https://img.shields.io/badge/tests-1%2C716_passing-brightgreen?style=for-the-badge)]()
 [![License](https://img.shields.io/badge/license-MIT-green?style=for-the-badge)](LICENSE)
 
 ---
@@ -148,7 +148,7 @@ AI agents don't need a SQL engine -- they need targeted, trusted context. Sharc 
 
 ```bash
 dotnet build                                            # Build everything
-dotnet test                                             # Run all 1,646 tests
+dotnet test                                             # Run all 1,716 tests
 dotnet run -c Release --project bench/Sharc.Benchmarks  # Run benchmarks
 ```
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,11 +6,13 @@
 Sharc is a **high-performance, managed context engine** for AI agents. It reads and writes the standard SQLite file format (Format 3) but bypasses the SQLite library entirely to achieve **2-75x faster read performance**. It is built in pure C# with no native dependencies.
 
 ### Why not just use SQLite?
-If you need complex SQL (JOINs, GROUP BY, CTEs) or legacy compatibility, use SQLite.
+If you need JOINs, views, triggers, or stored procedures, use SQLite. Sharc now supports `GROUP BY`, CTEs, and compound queries (`UNION`/`INTERSECT`/`EXCEPT`) via the Query API.
+
 **Use Sharc when:**
-*   **Latency matters:** You need 585ns point lookups (vs 26µs in SQLite).
+
+*   **Latency matters:** You need sub-microsecond point lookups (392ns vs 24,011ns in SQLite).
 *   **Memory matters:** You need zero per-row allocations (using `ref struct` and `Span<T>`).
-*   **Context matters:** You need to traverse graphs (`node |> edge`) instantly.
+*   **Context matters:** You need to traverse graphs at 13.5x the speed of SQLite recursive CTEs.
 *   **Deployment matters:** You need a <50KB WASM binary (vs 1MB+ for SQLite WASM).
 
 ### Is this production-ready?
@@ -38,16 +40,21 @@ Use the Write Engine *only* for:
 *   See [Deep Dive: Parsing](DeepDive_Parsing.md) for the architecture.
 
 ### What is "Arrow Syntax" (`|>`)?
+
+> **Parsed but not yet executable.** Arrow syntax is recognized by the Sharq parser but graph traversal execution via SQL is planned for a future release. Use the Graph API directly (`SharcContextGraph`) for graph traversal today.
+
 Sharq extends SQL with graph traversal operators.
 Instead of complicated `JOIN` syntax, you can write:
 ```sql
 SELECT id |> friend |> name FROM users
 ```
-This compiles to a direct B-tree graph scan, which is ~13.5x faster than a recursive CTE in SQLite.
+The Graph API already achieves ~13.5x faster traversal than SQLite recursive CTEs.
 See [Sharq Reference](ParsingTsql.md).
 
 ### Can I just use regular SQL?
-Yes! Sharq supports standard `SELECT`, `FROM`, `WHERE`, `ORDER BY`, `LIMIT`, and `OFFSET`. You only need to learn the new syntax if you want to use the Graph Engine features.
+Yes! Sharq supports `SELECT`, `FROM`, `WHERE`, `ORDER BY`, `GROUP BY`, `HAVING`, `LIMIT`, `OFFSET`, `UNION`/`INTERSECT`/`EXCEPT`, CTEs (`WITH ... AS`), and parameterized queries (`$param`). You only need the arrow syntax for Graph Engine features.
+
+> **Note:** `CASE` expressions and window functions (`OVER`, `PARTITION BY`) are parsed but not yet executable. `JOIN` is not supported â€” use `UNION`/CTE for multi-table workflows.
 
 ---
 

--- a/docs/WHEN_NOT_TO_USE.md
+++ b/docs/WHEN_NOT_TO_USE.md
@@ -4,14 +4,15 @@ Sharc is a specialized **Context Engine**, not a general-purpose database. Hones
 
 ## 🛑 STOP if you need:
 
-### 1. Complex SQL (Aggregations, JOINs, CTEs)
-Sharc has a **query parser** (Sharq), but it is optimized for finding and filtering nodes. It does **NOT** support:
-*   `GROUP BY`, `HAVING`, `SUM`, `AVG`, `MAX`
-*   `JOIN` (use `|>` graph syntax instead, or join in memory)
-*   Common Table Expressions (CTEs)
-*   Views, Triggers, or Stored Procedures
+### 1. SQL JOINs, Views, Triggers, or Stored Procedures
 
-**Use SQLite** for analytics, reporting, and heavy data aggregation.
+Sharc's query pipeline now supports `GROUP BY`, `HAVING`, `COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, CTEs (`WITH ... AS`), and compound queries (`UNION`, `INTERSECT`, `EXCEPT`). However, it does **NOT** support:
+
+*   `JOIN` (use `UNION`/CTE for multi-table workflows, or the Graph API for relationship traversal)
+*   Views, Triggers, or Stored Procedures
+*   `CASE` expressions, Window Functions (parsed but not yet executable)
+
+**Use SQLite** if you need JOINs, views, triggers, or complex multi-table queries. For large-scale analytics, consider DuckDB.
 
 ### 2. General-Purpose Writes (UPDATE / DELETE)
 The Sharc Write Engine is **EXPERIMENTAL** and **APPEND-ONLY**.
@@ -35,7 +36,7 @@ Sharc is a row-store. It reads row-by-row. If you need to scan 10GB of data to c
 | Capability | Why Sharc Wins |
 | :--- | :--- |
 | **Graph Traversal** | `node |> edge |> target` syntax is **13.5x faster** than SQLite Recursive CTEs. |
-| **Point Lookups** | **585ns** vs 26,000ns. If you do thousands of lookups per request, Sharc is the only choice. |
+| **Point Lookups** | **392ns** vs 24,011ns (61x faster). If you do thousands of lookups per request, Sharc is the only choice. |
 | **Agent Context** | Precision retrieval allows you to fit **100% relevant context** into small token windows. |
 | **Trust & Audit** | Built-in cryptographic ledger (`_sharc_ledger`) proves *who* wrote *what*. |
 | **WASM / Edge** | **<50KB** binary. Runs in-browser without Emscripten or multithreading headers. |

--- a/tests/Sharc.Tests/Query/QueryPostProcessorTests.cs
+++ b/tests/Sharc.Tests/Query/QueryPostProcessorTests.cs
@@ -1,0 +1,245 @@
+// Copyright (c) Ram Revanur. All rights reserved.
+// Licensed under the MIT License.
+
+using Sharc.Query;
+using Sharc.Query.Intent;
+using Xunit;
+
+namespace Sharc.Tests.Query;
+
+public class QueryPostProcessorTests
+{
+    private static QueryValue[] Row(long a) => [QueryValue.FromInt64(a)];
+    private static QueryValue[] Row(long a, string b) => [QueryValue.FromInt64(a), QueryValue.FromString(b)];
+    private static QueryValue[] Row(string a) => [QueryValue.FromString(a)];
+
+    // ─── ApplyOrderBy ──────────────────────────────────────────
+
+    [Fact]
+    public void ApplyOrderBy_SingleColumnAscending_SortsCorrectly()
+    {
+        var rows = new List<QueryValue[]> { Row(3), Row(1), Row(2) };
+        var orderBy = new List<OrderIntent> { new() { ColumnName = "id", Descending = false } };
+        var columns = new[] { "id" };
+
+        QueryPostProcessor.ApplyOrderBy(rows, orderBy, columns);
+
+        Assert.Equal(1L, rows[0][0].AsInt64());
+        Assert.Equal(2L, rows[1][0].AsInt64());
+        Assert.Equal(3L, rows[2][0].AsInt64());
+    }
+
+    [Fact]
+    public void ApplyOrderBy_SingleColumnDescending_SortsReversed()
+    {
+        var rows = new List<QueryValue[]> { Row(1), Row(3), Row(2) };
+        var orderBy = new List<OrderIntent> { new() { ColumnName = "id", Descending = true } };
+        var columns = new[] { "id" };
+
+        QueryPostProcessor.ApplyOrderBy(rows, orderBy, columns);
+
+        Assert.Equal(3L, rows[0][0].AsInt64());
+        Assert.Equal(2L, rows[1][0].AsInt64());
+        Assert.Equal(1L, rows[2][0].AsInt64());
+    }
+
+    [Fact]
+    public void ApplyOrderBy_MultiColumn_SortsByPrimaryThenSecondary()
+    {
+        var rows = new List<QueryValue[]>
+        {
+            Row(1, "b"), Row(1, "a"), Row(2, "c"), Row(2, "a")
+        };
+        var orderBy = new List<OrderIntent>
+        {
+            new() { ColumnName = "id", Descending = false },
+            new() { ColumnName = "name", Descending = false }
+        };
+        var columns = new[] { "id", "name" };
+
+        QueryPostProcessor.ApplyOrderBy(rows, orderBy, columns);
+
+        Assert.Equal("a", rows[0][1].AsString()); // (1, "a")
+        Assert.Equal("b", rows[1][1].AsString()); // (1, "b")
+        Assert.Equal("a", rows[2][1].AsString()); // (2, "a")
+        Assert.Equal("c", rows[3][1].AsString()); // (2, "c")
+    }
+
+    [Fact]
+    public void ApplyOrderBy_EmptyRows_NoError()
+    {
+        var rows = new List<QueryValue[]>();
+        var orderBy = new List<OrderIntent> { new() { ColumnName = "id", Descending = false } };
+        var columns = new[] { "id" };
+
+        QueryPostProcessor.ApplyOrderBy(rows, orderBy, columns);
+
+        Assert.Empty(rows);
+    }
+
+    [Fact]
+    public void ApplyOrderBy_NullValues_SortLast()
+    {
+        var rows = new List<QueryValue[]>
+        {
+            new[] { QueryValue.Null }, Row(1), new[] { QueryValue.Null }, Row(2)
+        };
+        var orderBy = new List<OrderIntent> { new() { ColumnName = "id", Descending = false } };
+        var columns = new[] { "id" };
+
+        QueryPostProcessor.ApplyOrderBy(rows, orderBy, columns);
+
+        Assert.Equal(1L, rows[0][0].AsInt64());
+        Assert.Equal(2L, rows[1][0].AsInt64());
+        Assert.True(rows[2][0].IsNull);
+        Assert.True(rows[3][0].IsNull);
+    }
+
+    [Fact]
+    public void ApplyOrderBy_UnknownColumn_ThrowsArgumentException()
+    {
+        var rows = new List<QueryValue[]> { Row(1) };
+        var orderBy = new List<OrderIntent> { new() { ColumnName = "nonexistent", Descending = false } };
+        var columns = new[] { "id" };
+
+        Assert.Throws<ArgumentException>(() =>
+            QueryPostProcessor.ApplyOrderBy(rows, orderBy, columns));
+    }
+
+    // ─── ApplyLimitOffset ──────────────────────────────────────
+
+    [Fact]
+    public void ApplyLimitOffset_LimitOnly_TruncatesRows()
+    {
+        var rows = new List<QueryValue[]> { Row(1), Row(2), Row(3), Row(4), Row(5) };
+        var result = QueryPostProcessor.ApplyLimitOffset(rows, 3, null);
+        Assert.Equal(3, result.Count);
+        Assert.Equal(1L, result[0][0].AsInt64());
+        Assert.Equal(3L, result[2][0].AsInt64());
+    }
+
+    [Fact]
+    public void ApplyLimitOffset_OffsetOnly_SkipsRows()
+    {
+        var rows = new List<QueryValue[]> { Row(1), Row(2), Row(3), Row(4), Row(5) };
+        var result = QueryPostProcessor.ApplyLimitOffset(rows, null, 2);
+        Assert.Equal(3, result.Count);
+        Assert.Equal(3L, result[0][0].AsInt64());
+    }
+
+    [Fact]
+    public void ApplyLimitOffset_BothLimitAndOffset_Slices()
+    {
+        var rows = new List<QueryValue[]> { Row(1), Row(2), Row(3), Row(4), Row(5) };
+        var result = QueryPostProcessor.ApplyLimitOffset(rows, 2, 1);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(2L, result[0][0].AsInt64());
+        Assert.Equal(3L, result[1][0].AsInt64());
+    }
+
+    [Fact]
+    public void ApplyLimitOffset_LimitExceedsRows_ReturnsAll()
+    {
+        var rows = new List<QueryValue[]> { Row(1), Row(2) };
+        var result = QueryPostProcessor.ApplyLimitOffset(rows, 100, null);
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void ApplyLimitOffset_OffsetExceedsRows_ReturnsEmpty()
+    {
+        var rows = new List<QueryValue[]> { Row(1), Row(2) };
+        var result = QueryPostProcessor.ApplyLimitOffset(rows, null, 100);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ApplyLimitOffset_ZeroLimit_ReturnsEmpty()
+    {
+        var rows = new List<QueryValue[]> { Row(1), Row(2), Row(3) };
+        var result = QueryPostProcessor.ApplyLimitOffset(rows, 0, null);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ApplyLimitOffset_NoLimitNoOffset_ReturnsSameList()
+    {
+        var rows = new List<QueryValue[]> { Row(1), Row(2) };
+        var result = QueryPostProcessor.ApplyLimitOffset(rows, null, null);
+        Assert.Same(rows, result); // same reference — no copy
+    }
+
+    [Fact]
+    public void ApplyLimitOffset_EmptyRows_ReturnsEmpty()
+    {
+        var rows = new List<QueryValue[]>();
+        var result = QueryPostProcessor.ApplyLimitOffset(rows, 10, 5);
+        Assert.Empty(result);
+    }
+
+    // ─── ResolveOrdinal ──────────────────────────────────────────
+
+    [Fact]
+    public void ResolveOrdinal_ExistingColumn_ReturnsIndex()
+    {
+        var columns = new[] { "id", "name", "age" };
+        Assert.Equal(1, QueryPostProcessor.ResolveOrdinal(columns, "name"));
+    }
+
+    [Fact]
+    public void ResolveOrdinal_CaseInsensitive_Matches()
+    {
+        var columns = new[] { "id", "Name", "age" };
+        Assert.Equal(1, QueryPostProcessor.ResolveOrdinal(columns, "name"));
+        Assert.Equal(1, QueryPostProcessor.ResolveOrdinal(columns, "NAME"));
+    }
+
+    [Fact]
+    public void ResolveOrdinal_NotFound_ThrowsArgumentException()
+    {
+        var columns = new[] { "id", "name" };
+        Assert.Throws<ArgumentException>(() =>
+            QueryPostProcessor.ResolveOrdinal(columns, "nonexistent"));
+    }
+
+    // ─── CompareValues ──────────────────────────────────────────
+
+    [Fact]
+    public void CompareValues_TwoIntegers_Compares()
+    {
+        var a = QueryValue.FromInt64(5);
+        var b = QueryValue.FromInt64(3);
+        Assert.True(QueryPostProcessor.CompareValues(a, b) > 0);
+    }
+
+    [Fact]
+    public void CompareValues_IntAndDouble_CrossTypeComparison()
+    {
+        var intVal = QueryValue.FromInt64(5);
+        var dblVal = QueryValue.FromDouble(5.0);
+        Assert.Equal(0, QueryPostProcessor.CompareValues(intVal, dblVal));
+    }
+
+    [Fact]
+    public void CompareValues_NullSortsLast()
+    {
+        var val = QueryValue.FromInt64(1);
+        var nul = QueryValue.Null;
+        Assert.True(QueryPostProcessor.CompareValues(val, nul) < 0); // val before null
+        Assert.True(QueryPostProcessor.CompareValues(nul, val) > 0); // null after val
+    }
+
+    [Fact]
+    public void CompareValues_BothNull_Equal()
+    {
+        Assert.Equal(0, QueryPostProcessor.CompareValues(QueryValue.Null, QueryValue.Null));
+    }
+
+    [Fact]
+    public void CompareValues_Strings_OrdinalComparison()
+    {
+        var a = QueryValue.FromString("apple");
+        var b = QueryValue.FromString("banana");
+        Assert.True(QueryPostProcessor.CompareValues(a, b) < 0);
+    }
+}

--- a/tests/Sharc.Tests/Query/SetOperationProcessorTests.cs
+++ b/tests/Sharc.Tests/Query/SetOperationProcessorTests.cs
@@ -1,0 +1,292 @@
+// Copyright (c) Ram Revanur. All rights reserved.
+// Licensed under the MIT License.
+
+using Sharc.Query;
+using Sharc.Query.Intent;
+using Xunit;
+
+namespace Sharc.Tests.Query;
+
+public class SetOperationProcessorTests
+{
+    private static QueryValue[] Row(long a) => [QueryValue.FromInt64(a)];
+    private static QueryValue[] Row(long a, string b) => [QueryValue.FromInt64(a), QueryValue.FromString(b)];
+
+    // ─── ApplyDistinct ──────────────────────────────────────────
+
+    [Fact]
+    public void ApplyDistinct_NoDuplicates_ReturnsAll()
+    {
+        var rows = new List<QueryValue[]> { Row(1), Row(2), Row(3) };
+        var result = SetOperationProcessor.ApplyDistinct(rows, 1);
+        Assert.Equal(3, result.Count);
+    }
+
+    [Fact]
+    public void ApplyDistinct_AllDuplicates_ReturnsSingle()
+    {
+        var rows = new List<QueryValue[]> { Row(1), Row(1), Row(1) };
+        var result = SetOperationProcessor.ApplyDistinct(rows, 1);
+        Assert.Single(result);
+        Assert.Equal(1L, result[0][0].AsInt64());
+    }
+
+    [Fact]
+    public void ApplyDistinct_PreservesFirstOccurrenceOrder()
+    {
+        var rows = new List<QueryValue[]> { Row(3), Row(1), Row(3), Row(2), Row(1) };
+        var result = SetOperationProcessor.ApplyDistinct(rows, 1);
+        Assert.Equal(3, result.Count);
+        Assert.Equal(3L, result[0][0].AsInt64());
+        Assert.Equal(1L, result[1][0].AsInt64());
+        Assert.Equal(2L, result[2][0].AsInt64());
+    }
+
+    [Fact]
+    public void ApplyDistinct_EmptyInput_ReturnsEmpty()
+    {
+        var rows = new List<QueryValue[]>();
+        var result = SetOperationProcessor.ApplyDistinct(rows, 1);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ApplyDistinct_MultiColumn_ComparesAllColumns()
+    {
+        var rows = new List<QueryValue[]>
+        {
+            Row(1, "a"), Row(1, "b"), Row(1, "a"), Row(2, "a")
+        };
+        var result = SetOperationProcessor.ApplyDistinct(rows, 2);
+        Assert.Equal(3, result.Count); // (1,a), (1,b), (2,a)
+    }
+
+    [Fact]
+    public void ApplyDistinct_NullValues_TreatsNullsAsEqual()
+    {
+        var nullRow1 = new QueryValue[] { QueryValue.Null };
+        var nullRow2 = new QueryValue[] { QueryValue.Null };
+        var rows = new List<QueryValue[]> { nullRow1, Row(1), nullRow2 };
+        var result = SetOperationProcessor.ApplyDistinct(rows, 1);
+        Assert.Equal(2, result.Count); // NULL and 1
+    }
+
+    // ─── UnionAll ──────────────────────────────────────────────
+
+    [Fact]
+    public void Apply_UnionAll_ConcatenatesWithoutDedup()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(2) };
+        var right = new List<QueryValue[]> { Row(2), Row(3) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.UnionAll, left, right, 1);
+        Assert.Equal(4, result.Count);
+    }
+
+    [Fact]
+    public void Apply_UnionAll_EmptyLeft_ReturnsRight()
+    {
+        var left = new List<QueryValue[]>();
+        var right = new List<QueryValue[]> { Row(1), Row(2) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.UnionAll, left, right, 1);
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void Apply_UnionAll_EmptyRight_ReturnsLeft()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(2) };
+        var right = new List<QueryValue[]>();
+        var result = SetOperationProcessor.Apply(CompoundOperator.UnionAll, left, right, 1);
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void Apply_UnionAll_BothEmpty_ReturnsEmpty()
+    {
+        var left = new List<QueryValue[]>();
+        var right = new List<QueryValue[]>();
+        var result = SetOperationProcessor.Apply(CompoundOperator.UnionAll, left, right, 1);
+        Assert.Empty(result);
+    }
+
+    // ─── Union (deduplicated) ──────────────────────────────────
+
+    [Fact]
+    public void Apply_Union_RemovesDuplicatesAcrossSides()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(2) };
+        var right = new List<QueryValue[]> { Row(2), Row(3) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Union, left, right, 1);
+        Assert.Equal(3, result.Count); // 1, 2, 3
+    }
+
+    [Fact]
+    public void Apply_Union_RemovesDuplicatesWithinSameSide()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(1), Row(2) };
+        var right = new List<QueryValue[]> { Row(3) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Union, left, right, 1);
+        Assert.Equal(3, result.Count); // 1, 2, 3
+    }
+
+    [Fact]
+    public void Apply_Union_AllIdentical_ReturnsSingle()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(1) };
+        var right = new List<QueryValue[]> { Row(1), Row(1) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Union, left, right, 1);
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void Apply_Union_EmptyInputs_ReturnsEmpty()
+    {
+        var left = new List<QueryValue[]>();
+        var right = new List<QueryValue[]>();
+        var result = SetOperationProcessor.Apply(CompoundOperator.Union, left, right, 1);
+        Assert.Empty(result);
+    }
+
+    // ─── Intersect ──────────────────────────────────────────────
+
+    [Fact]
+    public void Apply_Intersect_ReturnsOnlyCommonRows()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(2), Row(3) };
+        var right = new List<QueryValue[]> { Row(2), Row(3), Row(4) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Intersect, left, right, 1);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(2L, result[0][0].AsInt64());
+        Assert.Equal(3L, result[1][0].AsInt64());
+    }
+
+    [Fact]
+    public void Apply_Intersect_NoOverlap_ReturnsEmpty()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(2) };
+        var right = new List<QueryValue[]> { Row(3), Row(4) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Intersect, left, right, 1);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Apply_Intersect_DuplicatesInLeft_ReturnsOnce()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(1), Row(2) };
+        var right = new List<QueryValue[]> { Row(1) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Intersect, left, right, 1);
+        Assert.Single(result);
+        Assert.Equal(1L, result[0][0].AsInt64());
+    }
+
+    [Fact]
+    public void Apply_Intersect_EmptyLeft_ReturnsEmpty()
+    {
+        var left = new List<QueryValue[]>();
+        var right = new List<QueryValue[]> { Row(1), Row(2) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Intersect, left, right, 1);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Apply_Intersect_EmptyRight_ReturnsEmpty()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(2) };
+        var right = new List<QueryValue[]>();
+        var result = SetOperationProcessor.Apply(CompoundOperator.Intersect, left, right, 1);
+        Assert.Empty(result);
+    }
+
+    // ─── Except ──────────────────────────────────────────────
+
+    [Fact]
+    public void Apply_Except_RemovesRightFromLeft()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(2), Row(3) };
+        var right = new List<QueryValue[]> { Row(2) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Except, left, right, 1);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1L, result[0][0].AsInt64());
+        Assert.Equal(3L, result[1][0].AsInt64());
+    }
+
+    [Fact]
+    public void Apply_Except_NoOverlap_ReturnsAllLeft()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(2) };
+        var right = new List<QueryValue[]> { Row(3), Row(4) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Except, left, right, 1);
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void Apply_Except_AllExcluded_ReturnsEmpty()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(2) };
+        var right = new List<QueryValue[]> { Row(1), Row(2) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Except, left, right, 1);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Apply_Except_DuplicatesInLeft_DedupedInResult()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(1), Row(2) };
+        var right = new List<QueryValue[]> { Row(3) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Except, left, right, 1);
+        Assert.Equal(2, result.Count); // 1, 2 (deduped)
+    }
+
+    [Fact]
+    public void Apply_Except_EmptyRight_ReturnsLeftDeduped()
+    {
+        var left = new List<QueryValue[]> { Row(1), Row(1), Row(2) };
+        var right = new List<QueryValue[]>();
+        var result = SetOperationProcessor.Apply(CompoundOperator.Except, left, right, 1);
+        Assert.Equal(2, result.Count); // 1, 2
+    }
+
+    // ─── MultiColumn ──────────────────────────────────────────
+
+    [Fact]
+    public void Apply_Union_MultiColumn_ComparesAllColumns()
+    {
+        var left = new List<QueryValue[]> { Row(1, "a"), Row(1, "b") };
+        var right = new List<QueryValue[]> { Row(1, "a"), Row(2, "a") };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Union, left, right, 2);
+        Assert.Equal(3, result.Count); // (1,a), (1,b), (2,a)
+    }
+
+    [Fact]
+    public void Apply_Intersect_MultiColumn_MatchesOnAllColumns()
+    {
+        var left = new List<QueryValue[]> { Row(1, "a"), Row(1, "b") };
+        var right = new List<QueryValue[]> { Row(1, "a"), Row(2, "a") };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Intersect, left, right, 2);
+        Assert.Single(result); // only (1, "a") matches
+        Assert.Equal(1L, result[0][0].AsInt64());
+        Assert.Equal("a", result[0][1].AsString());
+    }
+
+    // ─── Null handling in set operations ──────────────────────
+
+    [Fact]
+    public void Apply_Union_NullRows_TreatsNullsAsEqual()
+    {
+        var nullRow = new QueryValue[] { QueryValue.Null };
+        var left = new List<QueryValue[]> { nullRow, Row(1) };
+        var right = new List<QueryValue[]> { new[] { QueryValue.Null }, Row(2) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Union, left, right, 1);
+        Assert.Equal(3, result.Count); // NULL, 1, 2
+    }
+
+    [Fact]
+    public void Apply_Intersect_NullInBothSides_ReturnsNull()
+    {
+        var left = new List<QueryValue[]> { new[] { QueryValue.Null }, Row(1) };
+        var right = new List<QueryValue[]> { new[] { QueryValue.Null }, Row(2) };
+        var result = SetOperationProcessor.Apply(CompoundOperator.Intersect, left, right, 1);
+        Assert.Single(result);
+        Assert.True(result[0][0].IsNull);
+    }
+}


### PR DESCRIPTION
## Summary

- **SharQL query pipeline**: Full SQL query support — SELECT, WHERE, ORDER BY, GROUP BY, UNION/INTERSECT/EXCEPT, CTEs, parameterized queries — via a hand-written recursive-descent parser compiled to QueryIntent IR
- **SOLID decomposition**: Broke god classes (QueryPostProcessor 508→138 lines, CompoundQueryExecutor 460→146 lines) into 8 focused single-responsibility files
- **Allocation reduction**: TopNHeap row pooling, cached ColumnsArray, ArrayPool for reader arrays — WHERE+ORDER BY+LIMIT 78 KB→55 KB (-29%), UNION ALL+ORDER BY+LIMIT 54 KB→32 KB (-41%)
- **Streaming optimizations**: Streaming top-N heap, streaming aggregation (O(G) memory), zero-copy UNION ALL concatenation
- **Entitlement enforcement**: Agent trust layer integration for query-level access control
- **P0 credibility fixes**: Resolved doc contradictions (LIMITATIONS.md, WHEN_NOT_TO_USE.md, FAQ.md said "No GROUP BY/CTEs" when they work), aligned seek numbers across all docs (392ns), added benchmark fairness notes, added parsed-not-executable markers for arrow syntax/CASE/window functions
- **70 new unit tests**: SetOperationProcessor (28), QueryPostProcessor (22), SharqParser negative paths (12), IntentCompiler negative paths (8)
- **1,716 tests passing** across all 6 test projects

## Test plan

- [x] All 1,716 tests passing (`dotnet test`)
- [x] Build clean with zero warnings
- [x] Benchmarks run — allocation reductions confirmed
- [x] No public API surface changes
- [x] Doc contradictions resolved (LIMITATIONS.md, WHEN_NOT_TO_USE.md, FAQ.md)
- [x] Benchmark fairness disclosed (QueryPlanCache, UNION ALL architecture, memory reporting)