### PR TITLE
fix: resolve html entity rendering and missing sqlite native dependency

### DIFF
--- a/src/Sharc.Arena.Wasm/Components/ArenaHeader.razor
+++ b/src/Sharc.Arena.Wasm/Components/ArenaHeader.razor
@@ -1,7 +1,7 @@
 @* Arena header with title, preset selector, run controls, and engine legend *@
 
 <header class="arena-header">
-    <div class="arena-header-badge">&#x1F988; SHARC BENCHMARK ARENA</div>
+    <div class="arena-header-badge">🦈 SHARC BENCHMARK ARENA</div>
     <h1 class="arena-header-title">Core Engine Benchmarks</h1>
     <p class="arena-header-subtitle">
         @Slides.Count benchmarks &middot; @Engines.Count engines &middot; Sequential &middot; ~@EstimateSeconds()s

--- a/src/Sharc.Arena.Wasm/Components/CtaPage.razor
+++ b/src/Sharc.Arena.Wasm/Components/CtaPage.razor
@@ -6,7 +6,7 @@
 
     <div class="cta-paths">
         <div class="cta-card developer">
-            <span class="cta-card-icon">&#x1F4BB;</span>
+            <span class="cta-card-icon">💻</span>
             <h3 class="cta-card-title">Developer</h3>
             <p class="cta-card-desc">NuGet package, zero config, works everywhere .NET runs</p>
             <div class="cta-card-actions">
@@ -16,7 +16,7 @@
         </div>
 
         <div class="cta-card decision-maker">
-            <span class="cta-card-icon">&#x1F4CA;</span>
+            <span class="cta-card-icon">📊</span>
             <h3 class="cta-card-title">Decision Maker</h3>
             <p class="cta-card-desc">Reduce agent latency by 7x, cut binary size by 30x, add cryptographic trust</p>
             <div class="cta-card-actions">

--- a/src/Sharc.Arena.Wasm/Components/HookPage.razor
+++ b/src/Sharc.Arena.Wasm/Components/HookPage.razor
@@ -10,8 +10,8 @@
 
     <div class="hook-pillars">
         <ValuePillar Icon="&#x26A1;" Stat="7.1x" Label="Faster B-tree seeks" />
-        <ValuePillar Icon="&#x1F4E6;" Stat="50 KB" Label="Total engine size" />
-        <ValuePillar Icon="&#x1F30D;" Stat="12.5x" Label="Faster graph traversal" />
+        <ValuePillar Icon="📦" Stat="50 KB" Label="Total engine size" />
+        <ValuePillar Icon="🌍" Stat="12.5x" Label="Faster graph traversal" />
     </div>
 
     <div class="hook-cta">

--- a/src/Sharc.Arena.Wasm/Sharc.Arena.Wasm.csproj
+++ b/src/Sharc.Arena.Wasm/Sharc.Arena.Wasm.csproj
@@ -20,6 +20,8 @@
     <!-- DataGenerator uses Microsoft.Data.Sqlite for in-memory DB → byte[] export -->
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" VersionOverride="2.1.10" />
+    <!-- Ensure native static library is linked for WASM -->
+    <NativeFileReference Include="$(NuGetPackageRoot)sqlitepclraw.lib.e_sqlite3\2.1.10\runtimes\browser-wasm\nativeassets\net6.0\e_sqlite3.a" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR addresses two critical issues found on the live site:
1.  **HTML Entity Rendering**: Replaced raw HTML entities (e.g., `&#x1F4E6;`) with direct emoji characters in `HookPage.razor`, `CtaPage.razor`, and `ArenaHeader.razor` to prevent double-encoding.
2.  **SQLite Native Dependency**: Explicitly added `<NativeFileReference>` for `e_sqlite3.a` in `Sharc.Arena.Wasm.csproj`. This resolves the `System.DllNotFoundException: e_sqlite3` error preventing benchmarks from running in the browser.