### PR TITLE
fix(wasm): Explicitly copy e_sqlite3.a to output

### DIFF
--- a/src/Sharc.Arena.Wasm/Sharc.Arena.Wasm.csproj
+++ b/src/Sharc.Arena.Wasm/Sharc.Arena.Wasm.csproj
@@ -24,6 +24,15 @@
     <NativeFileReference Include="$(NuGetPackageRoot)sqlitepclraw.lib.e_sqlite3\2.1.10\runtimes\browser-wasm\nativeassets\net6.0\e_sqlite3.a" />
   </ItemGroup>
 
+  <!-- Explicitly copy native asset to output to ensure it's available if dynamic loading occurs -->
+  <Target Name="CopyNativeAssets" AfterTargets="Build">
+    <ItemGroup>
+      <_NativeAsset Include="$(NuGetPackageRoot)sqlitepclraw.lib.e_sqlite3\2.1.10\runtimes\browser-wasm\nativeassets\net6.0\e_sqlite3.a" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_NativeAsset)" DestinationFolder="$(OutDir)wwwroot\_framework" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(_NativeAsset)" DestinationFolder="$(PublishDir)wwwroot\_framework" SkipUnchangedFiles="true" Condition="'$(PublishDir)' != ''" />
+  </Target>
+
   <ItemGroup>
     <!-- Tier 1: Sharc (pure C#) -->
     <ProjectReference Include="..\Sharc\Sharc.csproj" />


### PR DESCRIPTION
This PR resolves the `DllNotFoundException: e_sqlite3` error on the live benchmark site.
It adds a `CopyNativeAssets` target to `Sharc.Arena.Wasm.csproj` to explicitly copy the `e_sqlite3.a` static library from the NuGet package to the `wwwroot/_framework` directory during build and publish.
This ensures the native asset is available for the runtime.