### PR TITLE
fix(ci): install wasm-tools workload for e_sqlite3 native linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+
       - name: Restore dependencies
         run: |
           dotnet restore Sharc.sln

--- a/.github/workflows/deploy-arena.yml
+++ b/.github/workflows/deploy-arena.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+
       - name: Publish Sharc.Arena.Wasm
         run: dotnet publish src/Sharc.Arena.Wasm/Sharc.Arena.Wasm.csproj -c Release -o release --nologo
 


### PR DESCRIPTION
Without wasm-tools, dotnet publish skips WASM native relinking and e_sqlite3.a never gets linked into dotnet.native.wasm. This causes TypeInitializationException for SqliteConnection at runtime.