### PR TITLE
fix(arena): register DataGenerator in DI for SqlPlaygroundEngine

### DIFF
--- a/src/Sharc.Arena.Wasm/Program.cs
+++ b/src/Sharc.Arena.Wasm/Program.cs
@@ -48,6 +48,9 @@ public partial class Program
         // Query pipeline: reference data for 13-query comparison
         builder.Services.AddScoped<QueryPipelineEngine>();
 
+        // Shared data generator (used by BenchmarkRunner and SqlPlaygroundEngine)
+        builder.Services.AddSingleton<DataGenerator>();
+
         // SQL Playground: live Sharc vs SQLite query comparison
         builder.Services.AddScoped<SqlPlaygroundEngine>();
     }

--- a/src/Sharc.Arena.Wasm/Services/BenchmarkRunner.cs
+++ b/src/Sharc.Arena.Wasm/Services/BenchmarkRunner.cs
@@ -23,7 +23,7 @@ public sealed class BenchmarkRunner : IBenchmarkEngine
     private readonly SqliteEngine _sqliteEngine;
     private readonly IndexedDbEngine _indexedDbEngine;
     private readonly ReferenceEngine _referenceEngine;
-    private readonly DataGenerator _dataGenerator = new();
+    private readonly DataGenerator _dataGenerator;
 
     private byte[]? _dbBytes;
     private int _lastUserCount;
@@ -33,12 +33,14 @@ public sealed class BenchmarkRunner : IBenchmarkEngine
         SharcEngine sharcEngine,
         SqliteEngine sqliteEngine,
         IndexedDbEngine indexedDbEngine,
-        ReferenceEngine referenceEngine)
+        ReferenceEngine referenceEngine,
+        DataGenerator dataGenerator)
     {
         _sharcEngine = sharcEngine;
         _sqliteEngine = sqliteEngine;
         _indexedDbEngine = indexedDbEngine;
         _referenceEngine = referenceEngine;
+        _dataGenerator = dataGenerator;
     }
 
     public async Task<IReadOnlyDictionary<string, EngineBaseResult>> RunSlideAsync(


### PR DESCRIPTION
SqlPlaygroundEngine requires DataGenerator via constructor injection, but it was never registered in the DI container. This caused the entire Arena page to crash when Blazor tried to render the Playground section.

Also inject DataGenerator into BenchmarkRunner instead of newing it up.