### PR TITLE
perf: O(K²)→O(K) column offset precomputation + benchmark methodology

### DIFF
--- a/PRC/ArchitectureOverview.md
+++ b/PRC/ArchitectureOverview.md
@@ -299,4 +299,4 @@ new SharcOpenOptions
 
 ### Current Test Status
 
-**2,038 tests passing** across 6 projects (unit + integration + query + graph + index + context).
+**1,613 tests passing** across 5 projects (unit + integration + graph + index + context).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,7 @@ Sharc eliminates the "General Purpose Tax" of SQLite:
 | **Simd Tokenizer** | `SharqTokenizer` uses .NET 8 `SearchValues<char>` to scan queries at GB/s. |
 | **JIT Filtering** | `FilterStarCompiler` emits dynamic IL delegates for predicates, beating interpreted bytecode. |
 | **Zero Allocation** | `RecordDecoder` uses `ref struct` and `Span<T>` to read directly from page buffers. |
+| **O(1) Column Access** | `ComputeColumnOffsets()` precomputes all column byte offsets once per row in O(K), then each column access is O(1) via precomputed offset — eliminates O(K²) per-row overhead. |
 | **Graph Indexing** | `RelationStore` uses O(log N) B-tree seeks instead of recursive SQL joins (13.5x speedup). |
 
 ## Key Design Decisions

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -213,7 +213,9 @@ These have no SQLite equivalent -- they measure raw byte-level decode speed.
 | | `Cote + UNION ALL` | **273 us** | 972 us | **3.6x** | 1.4 KB |
 | **Parameterized** | `WHERE $param AND $param` | **223 us** | 819 us | **3.7x** | 81 KB |
 
-> **Sharc wins or ties every benchmark.** Key optimizations: lazy column decode (576 B for full-table scan), cached Cote intent resolution with inlined filters (808 B, 3.1x faster), predicate pushdown, filter compilation caching, query plan + intent caching, streaming 3-way UNION ALL, JIT-specialized struct comparer for TopN heap, ArrayPool-backed IndexSet for set dedup (1.4 KB vs 1.2 MB), index-based string pooling for aggregates.
+> **Sharc wins or ties every benchmark.** Key optimizations: O(K) column offset precomputation (eliminates O(K²) per-row decode overhead), lazy column decode (576 B for full-table scan), cached Cote intent resolution with inlined filters (808 B, 3.1x faster), predicate pushdown, filter compilation caching, query plan + intent caching, streaming 3-way UNION ALL, JIT-specialized struct comparer for TopN heap, ArrayPool-backed IndexSet for set dedup (1.4 KB vs 1.2 MB), index-based string pooling for aggregates.
+>
+> **Methodology**: 3 warmup iterations + 5 measured iterations (interleaved Sharc/SQLite to level GC pressure), median selected. Allocation measured on first iteration via `GC.GetAllocatedBytesForCurrentThread()`.
 
 ---
 

--- a/src/Sharc.Core/IRecordDecoder.cs
+++ b/src/Sharc.Core/IRecordDecoder.cs
@@ -99,6 +99,41 @@ public interface IRecordDecoder
     double DecodeDoubleDirect(ReadOnlySpan<byte> payload, int columnIndex, ReadOnlySpan<long> serialTypes, int bodyOffset);
 
     /// <summary>
+    /// Decodes a single column using a precomputed byte offset (O(1) per column).
+    /// Use with <see cref="ComputeColumnOffsets"/> to eliminate the O(K) per-access
+    /// offset scan in <see cref="DecodeColumn(ReadOnlySpan{byte}, int, ReadOnlySpan{long}, int)"/>.
+    /// </summary>
+    /// <param name="payload">The raw record bytes.</param>
+    /// <param name="serialType">The serial type of the target column.</param>
+    /// <param name="columnOffset">The precomputed byte offset within the payload.</param>
+    ColumnValue DecodeColumnAt(ReadOnlySpan<byte> payload, long serialType, int columnOffset);
+
+    /// <summary>
+    /// Decodes an INTEGER column at a precomputed offset (O(1)).
+    /// </summary>
+    long DecodeInt64At(ReadOnlySpan<byte> payload, long serialType, int columnOffset);
+
+    /// <summary>
+    /// Decodes a REAL column at a precomputed offset (O(1)).
+    /// </summary>
+    double DecodeDoubleAt(ReadOnlySpan<byte> payload, long serialType, int columnOffset);
+
+    /// <summary>
+    /// Decodes a TEXT column at a precomputed offset (O(1)).
+    /// </summary>
+    string DecodeStringAt(ReadOnlySpan<byte> payload, long serialType, int columnOffset);
+
+    /// <summary>
+    /// Computes cumulative byte offsets for all columns from pre-parsed serial types.
+    /// Converts O(K) per-access offset calculation into O(1) via a single precomputation pass.
+    /// </summary>
+    /// <param name="serialTypes">Pre-parsed serial types.</param>
+    /// <param name="columnCount">Number of columns to process.</param>
+    /// <param name="bodyOffset">Byte offset where the record body begins.</param>
+    /// <param name="offsets">Destination array for cumulative offsets (one per column).</param>
+    void ComputeColumnOffsets(ReadOnlySpan<long> serialTypes, int columnCount, int bodyOffset, Span<int> offsets);
+
+    /// <summary>
     /// Evaluates filters directly against the raw payload without decoding the full row.
     /// </summary>
     /// <param name="payload">The raw record bytes.</param>

--- a/tests/Sharc.Tests/BTree/WithoutRowIdCursorAdapterTests.cs
+++ b/tests/Sharc.Tests/BTree/WithoutRowIdCursorAdapterTests.cs
@@ -170,5 +170,10 @@ public sealed class WithoutRowIdCursorAdapterTests
         public string DecodeStringDirect(ReadOnlySpan<byte> payload, int columnIndex, ReadOnlySpan<long> serialTypes, int bodyOffset) => string.Empty;
         public long DecodeInt64Direct(ReadOnlySpan<byte> payload, int columnIndex, ReadOnlySpan<long> serialTypes, int bodyOffset) => 0;
         public double DecodeDoubleDirect(ReadOnlySpan<byte> payload, int columnIndex, ReadOnlySpan<long> serialTypes, int bodyOffset) => 0;
+        public ColumnValue DecodeColumnAt(ReadOnlySpan<byte> payload, long serialType, int columnOffset) => ColumnValue.Null();
+        public long DecodeInt64At(ReadOnlySpan<byte> payload, long serialType, int columnOffset) => 0;
+        public double DecodeDoubleAt(ReadOnlySpan<byte> payload, long serialType, int columnOffset) => 0;
+        public string DecodeStringAt(ReadOnlySpan<byte> payload, long serialType, int columnOffset) => string.Empty;
+        public void ComputeColumnOffsets(ReadOnlySpan<long> serialTypes, int columnCount, int bodyOffset, Span<int> offsets) { }
     }
 }

--- a/tests/Sharc.Tests/Schema/SchemaReaderTests.cs
+++ b/tests/Sharc.Tests/Schema/SchemaReaderTests.cs
@@ -374,5 +374,10 @@ public class SchemaReaderTests
         public string DecodeStringDirect(ReadOnlySpan<byte> payload, int columnIndex, ReadOnlySpan<long> serialTypes, int bodyOffset) => throw new NotSupportedException();
         public long DecodeInt64Direct(ReadOnlySpan<byte> payload, int columnIndex, ReadOnlySpan<long> serialTypes, int bodyOffset) => throw new NotSupportedException();
         public double DecodeDoubleDirect(ReadOnlySpan<byte> payload, int columnIndex, ReadOnlySpan<long> serialTypes, int bodyOffset) => throw new NotSupportedException();
+        public ColumnValue DecodeColumnAt(ReadOnlySpan<byte> payload, long serialType, int columnOffset) => throw new NotSupportedException();
+        public long DecodeInt64At(ReadOnlySpan<byte> payload, long serialType, int columnOffset) => throw new NotSupportedException();
+        public double DecodeDoubleAt(ReadOnlySpan<byte> payload, long serialType, int columnOffset) => throw new NotSupportedException();
+        public string DecodeStringAt(ReadOnlySpan<byte> payload, long serialType, int columnOffset) => throw new NotSupportedException();
+        public void ComputeColumnOffsets(ReadOnlySpan<long> serialTypes, int columnCount, int bodyOffset, Span<int> offsets) => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
Precompute all column byte offsets once per row via ComputeColumnOffsets(), eliminating O(K) per-access offset recalculation that caused O(K²) total cost for full-row access. For 9-column Arena users table, reduces GetContentSize calls from 36 to 9 per row. Also hardens WASM benchmarks with 3 warmups + 5 interleaved iterations + median selection.