### PR TITLE
Perf: zero-alloc fingerprint hashing, Cote copy elimination, JOIN bui…

### DIFF
--- a/src/Sharc/Query/CoteExecutor.cs
+++ b/src/Sharc/Query/CoteExecutor.cs
@@ -68,7 +68,7 @@ internal static class CoteExecutor
             if (!needsFilter && !needsAggregate && !needsDistinct && !needsSort && !needsLimit)
                 return new SharcDataReader(coteData.Rows, coteData.Columns);
 
-            var rows = new RowSet(coteData.Rows);
+            RowSet rows = coteData.Rows;
             var columnNames = coteData.Columns;
 
             // Apply outer WHERE filter to Cote data
@@ -88,7 +88,12 @@ internal static class CoteExecutor
                 rows = SetOperationProcessor.ApplyDistinct(rows, columnNames.Length);
 
             if (needsSort)
+            {
+                // OrderBy sorts in-place — copy only if rows still references the shared Cote data
+                if (ReferenceEquals(rows, coteData.Rows))
+                    rows = new RowSet(rows);
                 QueryPostProcessor.ApplyOrderBy(rows, intent.OrderBy!, columnNames);
+            }
 
             if (needsLimit)
                 rows = QueryPostProcessor.ApplyLimitOffset(rows, intent.Limit, intent.Offset);


### PR DESCRIPTION
…ld-on-smaller-side

- Replace Encoding.UTF8.GetBytes() with Fnv1aHasher.AppendString() in fingerprint paths (GetMaterializedRowFingerprint, GetColumnFingerprint) — eliminates byte[] allocation per text value in UNION/INTERSECT/EXCEPT and GROUP BY text pooling
- Remove System.Runtime.InteropServices dependency from SharcDataReader
- Eliminate unconditional RowSet copy in CoteExecutor and CompoundQueryExecutor — copy is now conditional (only when OrderBy would sort shared Cote data in-place)
- Add early-return in CompoundQueryExecutor.ExecuteAndMaterialize for no-op Cotes
- JOIN HashJoin now builds hash table on the smaller side for INNER JOINs, reducing hash bucket memory when left table is smaller than right