### PR TITLE
Fix Arena cold-load benchmark: ms→µs unit mismatch and SpeedupBadge o…

### DIFF
--- a/src/Sharc.Arena.Wasm/Components/EngineResult.razor
+++ b/src/Sharc.Arena.Wasm/Components/EngineResult.razor
@@ -54,7 +54,7 @@ else
             }
         </div>
         <AllocationBar Allocation="@Result.Allocation" WidthPercent="@AllocBarWidth" Color="@(Engine.Color + "40")" />
-        @if (IsWinner && WinnerValue.HasValue && MaxValue > 0)
+        @if (IsWinner && WinnerValue.HasValue && WinnerValue.Value > 0 && MaxValue > 0)
         {
             var speedup = MaxValue / WinnerValue.Value;
             <SpeedupBadge Speedup="@speedup" Color="@Engine.Color" />
@@ -101,7 +101,8 @@ else
             "ns" when val < 10     => $"{val:F1} ns",
             "ns"                   => $"{Math.Round(val)} ns",
 
-            "\u03BCs" when val >= 1000 => $"{val / 1000.0:F1} ms",
+            "\u03BCs" when val >= 1000  => $"{val / 1000.0:F1} ms",
+            "\u03BCs" when val < 0.1   => $"{val * 1000:F0} ns",
             "\u03BCs" when val < 10    => $"{val:F1} \u03BCs",
             "\u03BCs"                  => $"{Math.Round(val)} \u03BCs",
 

--- a/src/Sharc.Arena.Wasm/Components/SpeedupBadge.razor
+++ b/src/Sharc.Arena.Wasm/Components/SpeedupBadge.razor
@@ -13,7 +13,9 @@
 
     private string FormatSpeedup()
     {
-        if (Speedup >= 100) return $"{(int)Speedup}x";
+        if (double.IsInfinity(Speedup) || double.IsNaN(Speedup) || Speedup > 999_999)
+            return ">999999x";
+        if (Speedup >= 100) return $"{(long)Speedup}x";
         if (Speedup >= 10) return $"{Speedup:F0}x";
         return $"{Speedup:F1}x";
     }

--- a/src/Sharc.Arena.Wasm/Services/IndexedDbEngine.cs
+++ b/src/Sharc.Arena.Wasm/Services/IndexedDbEngine.cs
@@ -94,7 +94,7 @@ public sealed class IndexedDbEngine
 
         return new EngineBaseResult
         {
-            Value = Math.Round(initMs + loadMs, 2),
+            Value = Math.Round((initMs + loadMs) * 1000.0, 0),
             Note = $"IDB open: {initMs:F0}ms + populate: {loadMs:F0}ms",
         };
     }

--- a/src/Sharc.Arena.Wasm/Services/SharcEngine.cs
+++ b/src/Sharc.Arena.Wasm/Services/SharcEngine.cs
@@ -74,7 +74,7 @@ public sealed class SharcEngine : IDisposable
 
         return new EngineBaseResult
         {
-            Value = Math.Round(sw.Elapsed.TotalMilliseconds, 3),
+            Value = Math.Round(sw.Elapsed.TotalMicroseconds(), 1),
             Allocation = $"{allocKb:F1} KB",
             Note = "In-process \u2014 no WASM download",
         };

--- a/src/Sharc.Arena.Wasm/Services/SqliteEngine.cs
+++ b/src/Sharc.Arena.Wasm/Services/SqliteEngine.cs
@@ -72,7 +72,7 @@ public sealed class SqliteEngine : IDisposable
 
         return new EngineBaseResult
         {
-            Value = Math.Round(sw.Elapsed.TotalMilliseconds, 3),
+            Value = Math.Round(sw.Elapsed.TotalMilliseconds * 1000.0, 1),
             Allocation = $"{allocKb:F1} KB",
             Note = "Microsoft.Data.Sqlite — in-process P/Invoke",
         };


### PR DESCRIPTION
…verflow

All three RunEngineLoad() methods returned TotalMilliseconds but the slide unit is µs, causing Sharc to display "0.0 µs" (actual: ~4 µs), SQLite to show "1.2 µs" (actual: ~1,200 µs), and IndexedDB "313 µs" (actual: ~313 ms). SpeedupBadge cast (int)Speedup overflowed to -2147483648 on near-zero times.