### PR TITLE
Fix Arena benchmark display bugs and stale graph after engine-load

### DIFF
--- a/src/Sharc.Arena.Wasm/Components/EngineResult.razor
+++ b/src/Sharc.Arena.Wasm/Components/EngineResult.razor
@@ -54,7 +54,7 @@ else
             }
         </div>
         <AllocationBar Allocation="@Result.Allocation" WidthPercent="@AllocBarWidth" Color="@(Engine.Color + "40")" />
-        @if (IsWinner && WinnerValue.HasValue && MaxValue > 0)
+        @if (IsWinner && WinnerValue.HasValue && WinnerValue.Value > 0 && MaxValue > 0)
         {
             var speedup = MaxValue / WinnerValue.Value;
             <SpeedupBadge Speedup="@speedup" Color="@Engine.Color" />
@@ -101,7 +101,8 @@ else
             "ns" when val < 10     => $"{val:F1} ns",
             "ns"                   => $"{Math.Round(val)} ns",
 
-            "\u03BCs" when val >= 1000 => $"{val / 1000.0:F1} ms",
+            "\u03BCs" when val >= 1000  => $"{val / 1000.0:F1} ms",
+            "\u03BCs" when val < 0.1   => $"{val * 1000:F0} ns",
             "\u03BCs" when val < 10    => $"{val:F1} \u03BCs",
             "\u03BCs"                  => $"{Math.Round(val)} \u03BCs",
 

--- a/src/Sharc.Arena.Wasm/Components/SpeedupBadge.razor
+++ b/src/Sharc.Arena.Wasm/Components/SpeedupBadge.razor
@@ -13,7 +13,9 @@
 
     private string FormatSpeedup()
     {
-        if (Speedup >= 100) return $"{(int)Speedup}x";
+        if (double.IsInfinity(Speedup) || double.IsNaN(Speedup) || Speedup > 999_999)
+            return ">999999x";
+        if (Speedup >= 100) return $"{(long)Speedup}x";
         if (Speedup >= 10) return $"{Speedup:F0}x";
         return $"{Speedup:F1}x";
     }

--- a/src/Sharc.Arena.Wasm/Pages/Arena.razor
+++ b/src/Sharc.Arena.Wasm/Pages/Arena.razor
@@ -419,14 +419,17 @@ else
                 {
                     var scale = GetScaleForSlide(slide);
                     IBenchmarkEngine engine = _isLive ? LiveEngine : StaticEngine;
+                    Console.WriteLine($"[Arena] [{i+1}/{_slides.Count}] Running {slide.Id} (scale={scale:F3}, live={_isLive})");
+                    var slideSw = Stopwatch.StartNew();
                     var data = await engine.RunSlideAsync(slide, scale, token);
+                    Console.WriteLine($"[Arena] [{i+1}/{_slides.Count}] {slide.Id} done in {slideSw.ElapsedMilliseconds}ms");
 
                     _results[slide.Id] = data;
                     _doneSlides.Add(slide.Id);
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[Arena] Slide {slide.Id} failed: {ex.Message}");
+                    Console.WriteLine($"[Arena] Slide {slide.Id} failed: {ex.GetType().Name}: {ex.Message}");
                     _doneSlides.Add(slide.Id);
                 }
 

--- a/src/Sharc.Arena.Wasm/Services/DataGenerator.cs
+++ b/src/Sharc.Arena.Wasm/Services/DataGenerator.cs
@@ -263,17 +263,7 @@ public sealed class DataGenerator
 
     private static byte[] ExportToBytes(SqliteConnection connection)
     {
-        // Use SQLite backup API to export in-memory DB to a byte array
-        using var destConnection = new SqliteConnection("Data Source=:memory:");
-        destConnection.Open();
-
-        using var srcRaw = connection;
-        connection.BackupDatabase(destConnection);
-
-        // Now read from dest using VACUUM INTO a temp file approach
-        // Actually, simplest: serialize via the backup API to another in-memory DB,
-        // then export via custom serialization.
-        // Cleanest approach: write to temp file and read back
+        // Backup in-memory DB directly to a temp file and read back
         var tempPath = Path.GetTempFileName();
         try
         {

--- a/src/Sharc.Arena.Wasm/Services/IndexedDbEngine.cs
+++ b/src/Sharc.Arena.Wasm/Services/IndexedDbEngine.cs
@@ -94,7 +94,7 @@ public sealed class IndexedDbEngine
 
         return new EngineBaseResult
         {
-            Value = Math.Round(initMs + loadMs, 2),
+            Value = Math.Round((initMs + loadMs) * 1000.0, 0),
             Note = $"IDB open: {initMs:F0}ms + populate: {loadMs:F0}ms",
         };
     }

--- a/src/Sharc.Arena.Wasm/Services/SqliteEngine.cs
+++ b/src/Sharc.Arena.Wasm/Services/SqliteEngine.cs
@@ -72,7 +72,7 @@ public sealed class SqliteEngine : IDisposable
 
         return new EngineBaseResult
         {
-            Value = Math.Round(sw.Elapsed.TotalMilliseconds, 3),
+            Value = Math.Round(sw.Elapsed.TotalMilliseconds * 1000.0, 1),
             Allocation = $"{allocKb:F1} KB",
             Note = "Microsoft.Data.Sqlite — in-process P/Invoke",
         };


### PR DESCRIPTION
- RunEngineLoad: ms→µs unit mismatch in all 3 engines (Sharc showed "0.0 µs", SQLite showed "1.2 µs", IDB showed "313 µs" — all 1000x wrong)
- SpeedupBadge: (int) cast overflow to -2147483648 on large speedups
- EngineResult: guard division-by-zero when winner value is 0; add ns fallback for sub-0.1µs values
- SharcEngine.RunEngineLoad: dispose and re-init _graph alongside _db to prevent stale BTreeReader on subsequent graph benchmarks
- DataGenerator.ExportToBytes: remove redundant BackupDatabase call that doubled WASM export time
- Arena.razor: add per-slide Console.WriteLine diagnostics for debugging benchmark stalls (visible in browser DevTools)