### PR TITLE
feat: streaming TopK with custom row scorer + PrimeExample sample (v1…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,9 +42,9 @@
     <RepositoryType>git</RepositoryType>
 
     <!-- Assembly metadata -->
-    <AssemblyVersion>1.1.6.0</AssemblyVersion>
-    <FileVersion>1.1.6.0</FileVersion>
-    <Version>1.1.6-rc1</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
+    <Version>1.2.0</Version>
 
     <!-- Optimization for WASM/Size -->
     <IsTrimmable>true</IsTrimmable>

--- a/bench/Sharc.Benchmarks/BenchmarkTiers.cs
+++ b/bench/Sharc.Benchmarks/BenchmarkTiers.cs
@@ -64,6 +64,8 @@ internal static class BenchmarkTiers
         "*VarintBenchmarks.Read_9Byte",
         "*SerialTypeCodecBenchmarks.GetContentSize_Null",
         "*DatabaseHeaderBenchmarks.Parse_4096PageSize",
+        "*TopNPathBenchmarks.*",
+        "*SetOpFingerprintBenchmarks.*",
         "*TableScanBenchmarks.*_Scan100_*",
     ];
 
@@ -77,6 +79,8 @@ internal static class BenchmarkTiers
         "*SerialTypeCodecBenchmarks.GetContentSize_Null",
         "*DatabaseHeaderBenchmarks.Parse_4096PageSize",
         // Comparative — Light ops only
+        "*TopNPathBenchmarks.*",
+        "*SetOpFingerprintBenchmarks.*",
         "*DatabaseOpenBenchmarks.Sharc_Memory*",
         "*RealisticWorkloadBenchmarks.Sharc_OpenReadClose*",
     ];

--- a/bench/Sharc.Benchmarks/Micro/QueryPipelinePathBenchmarks.cs
+++ b/bench/Sharc.Benchmarks/Micro/QueryPipelinePathBenchmarks.cs
@@ -1,0 +1,236 @@
+// Copyright (c) Ram Revanur. All rights reserved.
+// Licensed under the MIT License.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.Data.Sqlite;
+
+namespace Sharc.Benchmarks.Micro;
+
+[BenchmarkCategory("Micro", "QueryPipeline", "TopN")]
+[MemoryDiagnoser]
+public class TopNPathBenchmarks
+{
+    private SharcDatabase _db = null!;
+
+    private const string TopNSingleKeyQuery = """
+        SELECT id, score, tie_break, payload_text, payload_blob, payload_note
+        FROM topn_source
+        ORDER BY score DESC
+        LIMIT 256 OFFSET 64
+        """;
+
+    private const string TopNTwoKeyQuery = """
+        SELECT id, score, tie_break, payload_text, payload_blob, payload_note
+        FROM topn_source
+        ORDER BY score DESC, tie_break DESC
+        LIMIT 256 OFFSET 64
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _db = SharcDatabase.OpenMemory(QueryPipelineBenchmarkData.GetBytes());
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _db.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public long TopN_TwoKey_MaterializedControl()
+    {
+        return CountRows(TopNTwoKeyQuery);
+    }
+
+    [Benchmark]
+    public long TopN_SingleKey_DeferredPath()
+    {
+        return CountRows(TopNSingleKeyQuery);
+    }
+
+    private long CountRows(string sql)
+    {
+        long count = 0;
+        using var reader = _db.Query(sql);
+        while (reader.Read())
+            count++;
+        return count;
+    }
+}
+
+[BenchmarkCategory("Micro", "QueryPipeline", "SetOpFingerprint")]
+[MemoryDiagnoser]
+public class SetOpFingerprintBenchmarks
+{
+    private SharcDatabase _db = null!;
+
+    private const string NumericFastPathQuery = """
+        SELECT metric FROM set_left
+        UNION
+        SELECT metric FROM set_right
+        """;
+
+    private const string TextFallbackQuery = """
+        SELECT label FROM set_left
+        UNION
+        SELECT label FROM set_right
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _db = SharcDatabase.OpenMemory(QueryPipelineBenchmarkData.GetBytes());
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _db.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public long SetOp_TextFallback()
+    {
+        return CountRows(TextFallbackQuery);
+    }
+
+    [Benchmark]
+    public long SetOp_NumericFastPath()
+    {
+        return CountRows(NumericFastPathQuery);
+    }
+
+    private long CountRows(string sql)
+    {
+        long count = 0;
+        using var reader = _db.Query(sql);
+        while (reader.Read())
+            count++;
+        return count;
+    }
+}
+
+internal static class QueryPipelineBenchmarkData
+{
+    private static readonly Lazy<byte[]> CachedBytes = new(BuildBytes);
+
+    internal static byte[] GetBytes() => CachedBytes.Value;
+
+    private static byte[] BuildBytes()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "sharc_bench");
+        Directory.CreateDirectory(dir);
+        string path = Path.Combine(dir, "query_pipeline_paths.db");
+        if (File.Exists(path))
+            File.Delete(path);
+
+        using (var conn = new SqliteConnection($"Data Source={path};Pooling=false"))
+        {
+            conn.Open();
+
+            using (var pragma = conn.CreateCommand())
+            {
+                pragma.CommandText = """
+                    PRAGMA journal_mode=DELETE;
+                    PRAGMA page_size=4096;
+                    PRAGMA synchronous=OFF;
+                    PRAGMA temp_store=MEMORY;
+                    """;
+                pragma.ExecuteNonQuery();
+            }
+
+            using (var schema = conn.CreateCommand())
+            {
+                schema.CommandText = """
+                    CREATE TABLE topn_source (
+                        id           INTEGER PRIMARY KEY,
+                        score        INTEGER NOT NULL,
+                        tie_break    INTEGER NOT NULL,
+                        payload_text TEXT NOT NULL,
+                        payload_blob BLOB NOT NULL,
+                        payload_note TEXT
+                    );
+
+                    CREATE TABLE set_left (
+                        metric INTEGER NOT NULL,
+                        label  TEXT NOT NULL
+                    );
+
+                    CREATE TABLE set_right (
+                        metric INTEGER NOT NULL,
+                        label  TEXT NOT NULL
+                    );
+                    """;
+                schema.ExecuteNonQuery();
+            }
+
+            var rng = new Random(1337);
+
+            using (var tx = conn.BeginTransaction())
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tx;
+                cmd.CommandText = """
+                    INSERT INTO topn_source (score, tie_break, payload_text, payload_blob, payload_note)
+                    VALUES (@score, @tie, @txt, @blob, @note)
+                    """;
+
+                var score = cmd.Parameters.Add("@score", SqliteType.Integer);
+                var tie = cmd.Parameters.Add("@tie", SqliteType.Integer);
+                var text = cmd.Parameters.Add("@txt", SqliteType.Text);
+                var blob = cmd.Parameters.Add("@blob", SqliteType.Blob);
+                var note = cmd.Parameters.Add("@note", SqliteType.Text);
+
+                for (int i = 0; i < 25_000; i++)
+                {
+                    score.Value = rng.Next(0, 2_000_000);
+                    tie.Value = rng.Next(0, 2_000_000);
+                    text.Value = $"payload_{i:D6}_{new string((char)('a' + (i % 26)), 48)}";
+
+                    var bytes = new byte[64];
+                    rng.NextBytes(bytes);
+                    blob.Value = bytes;
+
+                    note.Value = i % 4 == 0 ? DBNull.Value : $"note_{i:D6}";
+                    cmd.ExecuteNonQuery();
+                }
+
+                tx.Commit();
+            }
+
+            using (var tx = conn.BeginTransaction())
+            using (var left = conn.CreateCommand())
+            using (var right = conn.CreateCommand())
+            {
+                left.Transaction = tx;
+                right.Transaction = tx;
+                left.CommandText = "INSERT INTO set_left (metric, label) VALUES (@m, @l)";
+                right.CommandText = "INSERT INTO set_right (metric, label) VALUES (@m, @l)";
+
+                var lMetric = left.Parameters.Add("@m", SqliteType.Integer);
+                var lLabel = left.Parameters.Add("@l", SqliteType.Text);
+                for (int metric = 0; metric < 40_000; metric++)
+                {
+                    lMetric.Value = metric;
+                    lLabel.Value = $"m_{metric:D6}";
+                    left.ExecuteNonQuery();
+                }
+
+                var rMetric = right.Parameters.Add("@m", SqliteType.Integer);
+                var rLabel = right.Parameters.Add("@l", SqliteType.Text);
+                for (int metric = 20_000; metric < 60_000; metric++)
+                {
+                    rMetric.Value = metric;
+                    rLabel.Value = $"m_{metric:D6}";
+                    right.ExecuteNonQuery();
+                }
+
+                tx.Commit();
+            }
+        }
+
+        return File.ReadAllBytes(path);
+    }
+}

--- a/samples/PrimeExample/PrimeExample.csproj
+++ b/samples/PrimeExample/PrimeExample.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sharc\Sharc.csproj" />
+    <PackageReference Include="Microsoft.Data.Sqlite" />
+  </ItemGroup>
+</Project>

--- a/samples/PrimeExample/Program.cs
+++ b/samples/PrimeExample/Program.cs
@@ -1,0 +1,153 @@
+// PrimeExample — Streaming TopK with Custom Scoring
+//
+// Demonstrates how a project like PrimeSpiral can use Sharc's JitQuery.TopK()
+// to find the K nearest points to a target coordinate without materializing
+// the entire result set. Filters narrow the search space first, then the
+// scorer ranks only the surviving rows.
+
+using Microsoft.Data.Sqlite;
+using Sharc;
+using Sharc.Views;
+
+// ── 1. Generate a spatial dataset ────────────────────────────────────────────
+// Simulate 10,000 prime-spiral points with (x, y) coordinates and an arm label.
+
+var dbPath = Path.Combine(Path.GetTempPath(), "sharc_prime_example.db");
+if (File.Exists(dbPath)) File.Delete(dbPath);
+
+using (var conn = new SqliteConnection($"Data Source={dbPath}"))
+{
+    conn.Open();
+    using var cmd = conn.CreateCommand();
+    cmd.CommandText = """
+        CREATE TABLE points (
+            id   INTEGER PRIMARY KEY,
+            x    REAL,
+            y    REAL,
+            arm  TEXT
+        )
+        """;
+    cmd.ExecuteNonQuery();
+
+    // Insert 10,000 spiral-like points
+    using var tx = conn.BeginTransaction();
+    cmd.Transaction = tx;
+    string[] arms = ["alpha", "beta", "gamma", "delta"];
+    var rng = new Random(42);
+    for (int i = 0; i < 10_000; i++)
+    {
+        double angle = i * 0.1;
+        double r = 0.5 + i * 0.02 + rng.NextDouble() * 2;
+        double x = Math.Round(Math.Cos(angle) * r, 4);
+        double y = Math.Round(Math.Sin(angle) * r, 4);
+        string arm = arms[i % 4];
+        cmd.CommandText = $"INSERT INTO points (x, y, arm) VALUES ({x}, {y}, '{arm}')";
+        cmd.ExecuteNonQuery();
+    }
+    tx.Commit();
+}
+
+Console.WriteLine("PrimeExample: Streaming TopK with Custom Scoring");
+Console.WriteLine("================================================\n");
+
+using var db = SharcDatabase.Open(dbPath);
+
+// ── 2. Basic TopK: 10 nearest points to a target ────────────────────────────
+// No filters — just score all 10,000 points by Euclidean distance.
+
+double targetX = 50.0, targetY = 30.0;
+Console.WriteLine($"Target: ({targetX}, {targetY})\n");
+
+Console.WriteLine("--- Top 10 nearest points (no filter) ---");
+var jit = db.Jit("points");
+using var nearest = jit.TopK(10, new DistanceScorer(targetX, targetY), "id", "x", "y", "arm");
+
+while (nearest.Read())
+{
+    double dx = nearest.GetDouble(1) - targetX;
+    double dy = nearest.GetDouble(2) - targetY;
+    double dist = Math.Sqrt(dx * dx + dy * dy);
+    Console.WriteLine($"  id={nearest.GetInt64(0),5}  ({nearest.GetDouble(1),8:F2}, {nearest.GetDouble(2),8:F2})  arm={nearest.GetString(3),-6}  dist={dist:F4}");
+}
+
+// ── 3. Filtered TopK: spatial bounding box + arm filter ─────────────────────
+// First narrow with FilterStar (B-tree acceleration), then score survivors.
+// This is the pattern PrimeSpiral would use: space partition first, then rank.
+
+Console.WriteLine("\n--- Top 5 nearest 'alpha' points within bounding box ---");
+double radius = 80.0;
+jit.ClearFilters();
+jit.Where(FilterStar.Column("x").Between(targetX - radius, targetX + radius));
+jit.Where(FilterStar.Column("y").Between(targetY - radius, targetY + radius));
+jit.Where(FilterStar.Column("arm").Eq("alpha"));
+
+using var filtered = jit.TopK(5, new DistanceScorer(targetX, targetY), "id", "x", "y");
+
+while (filtered.Read())
+{
+    double dx = filtered.GetDouble(1) - targetX;
+    double dy = filtered.GetDouble(2) - targetY;
+    double dist = Math.Sqrt(dx * dx + dy * dy);
+    Console.WriteLine($"  id={filtered.GetInt64(0),5}  ({filtered.GetDouble(1),8:F2}, {filtered.GetDouble(2),8:F2})  dist={dist:F4}");
+}
+
+// ── 4. Lambda scorer: weighted distance ─────────────────────────────────────
+// For one-off scoring, use a lambda instead of implementing IRowScorer.
+
+Console.WriteLine("\n--- Top 5 by weighted distance (x weight=2, y weight=1) ---");
+jit.ClearFilters();
+using var weighted = jit.TopK(5,
+    row =>
+    {
+        double dx = row.GetDouble(1) - targetX;  // ordinal 1 = x (after projection)
+        double dy = row.GetDouble(2) - targetY;  // ordinal 2 = y
+        return Math.Sqrt(4 * dx * dx + dy * dy);  // x-axis weighted 2x
+    },
+    "id", "x", "y");
+
+while (weighted.Read())
+{
+    Console.WriteLine($"  id={weighted.GetInt64(0),5}  ({weighted.GetDouble(1),8:F2}, {weighted.GetDouble(2),8:F2})");
+}
+
+// ── 5. Reusable scorer class ────────────────────────────────────────────────
+// For repeated queries with different targets, implement IRowScorer once.
+
+Console.WriteLine("\n--- Reusable scorer: 3 nearest to (0, 0) then (-20, 15) ---");
+var scorer1 = new DistanceScorer(0, 0);
+var scorer2 = new DistanceScorer(-20, 15);
+
+jit.ClearFilters();
+using var near1 = jit.TopK(3, scorer1, "id", "x", "y");
+Console.WriteLine("  Near (0,0):");
+while (near1.Read())
+    Console.WriteLine($"    id={near1.GetInt64(0),5}  ({near1.GetDouble(1),8:F2}, {near1.GetDouble(2),8:F2})");
+
+jit.ClearFilters();
+using var near2 = jit.TopK(3, scorer2, "id", "x", "y");
+Console.WriteLine("  Near (-20,15):");
+while (near2.Read())
+    Console.WriteLine($"    id={near2.GetInt64(0),5}  ({near2.GetDouble(1),8:F2}, {near2.GetDouble(2),8:F2})");
+
+Console.WriteLine("\nDone.");
+
+// Cleanup
+try { File.Delete(dbPath); } catch { }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Scorer implementation — reusable across queries
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// <summary>
+/// Euclidean distance scorer. Lower distance = better score.
+/// Ordinals 1 and 2 correspond to x and y after projection (id=0, x=1, y=2).
+/// </summary>
+sealed class DistanceScorer(double cx, double cy) : IRowScorer
+{
+    public double Score(IRowAccessor row)
+    {
+        double dx = row.GetDouble(1) - cx;  // x column (ordinal 1 in projected output)
+        double dy = row.GetDouble(2) - cy;  // y column (ordinal 2 in projected output)
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -25,6 +25,7 @@ dotnet script ./samples/run-all.csx
 | `EncryptedRead` | Opening encrypted databases with decryption options |
 | `FilterAndProject` | Column filters and projection pipelines |
 | `PointLookup` | Primary-key seek / point lookup path |
+| `PrimeExample` | Streaming TopK with custom scoring (spatial nearest-neighbor) |
 | `TrustComplex` | Multi-agent trust, authority ceilings, and signatures |
 | `UpsertDeleteWhere` | Upsert and predicate-based deletes |
 | `VectorSearch` | Embedding storage and nearest-neighbor vector search |

--- a/src/Sharc/IRowScorer.cs
+++ b/src/Sharc/IRowScorer.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Ram Revanur. All rights reserved.
+// Licensed under the MIT License.
+
+using Sharc.Views;
+
+namespace Sharc;
+
+/// <summary>
+/// Computes a score for a row during streaming scans.
+/// Used with JitQuery.TopK to select the K best-scoring rows
+/// without materializing the entire result set.
+/// </summary>
+/// <remarks>
+/// Lower scores are considered better (natural for distance-based scoring).
+/// The scorer receives an <see cref="IRowAccessor"/> that provides lazy,
+/// zero-allocation access to column values — only accessed columns are decoded.
+/// </remarks>
+public interface IRowScorer
+{
+    /// <summary>
+    /// Computes a score for the current row. Lower values rank higher.
+    /// </summary>
+    /// <param name="row">Accessor for the current row's column values.</param>
+    /// <returns>A score where lower values are better (e.g., distance).</returns>
+    double Score(IRowAccessor row);
+}

--- a/src/Sharc/JitQuery.TopK.cs
+++ b/src/Sharc/JitQuery.TopK.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Ram Revanur. All rights reserved.
+// Licensed under the MIT License.
+
+using Sharc.Query;
+using Sharc.Views;
+
+namespace Sharc;
+
+public sealed partial class JitQuery
+{
+    /// <summary>
+    /// Executes the query with accumulated filters and returns the K best-scoring rows.
+    /// This is a terminal method — it runs the query immediately and returns a reader.
+    /// </summary>
+    /// <remarks>
+    /// <para>The scorer runs on each row after all filters (FilterStar, IRowAccessEvaluator)
+    /// have been applied. Rows that score worse than the current worst in the heap are
+    /// never materialized, keeping memory bounded to O(K).</para>
+    /// <para>Lower scores rank higher (natural for distance-based scoring).</para>
+    /// <para>The returned reader contains exactly min(K, matchCount) rows sorted
+    /// ascending by score (best first).</para>
+    /// </remarks>
+    /// <param name="k">Number of top-scoring rows to return. Must be greater than zero.</param>
+    /// <param name="scorer">The scoring function. Lower scores are better.</param>
+    /// <param name="columns">Column names to project, or empty/null for all columns.</param>
+    /// <returns>A <see cref="SharcDataReader"/> containing at most K rows sorted by score ascending.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="k"/> is zero or negative.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="scorer"/> is null.</exception>
+    public SharcDataReader TopK(int k, IRowScorer scorer, params string[]? columns)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(k, 0);
+        ArgumentNullException.ThrowIfNull(scorer);
+
+        var reader = Query(columns);
+        return ScoredTopKProcessor.Apply(reader, k, scorer);
+    }
+
+    /// <summary>
+    /// Executes the query with accumulated filters and returns the K best-scoring rows
+    /// using a lambda scoring function.
+    /// </summary>
+    /// <param name="k">Number of top-scoring rows to return. Must be greater than zero.</param>
+    /// <param name="scorer">Lambda that computes a score for each row. Lower scores are better.</param>
+    /// <param name="columns">Column names to project, or empty/null for all columns.</param>
+    /// <returns>A <see cref="SharcDataReader"/> containing at most K rows sorted by score ascending.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="k"/> is zero or negative.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="scorer"/> is null.</exception>
+    public SharcDataReader TopK(int k, Func<IRowAccessor, double> scorer, params string[]? columns)
+    {
+        ArgumentNullException.ThrowIfNull(scorer);
+        return TopK(k, new DelegateRowScorer(scorer), columns);
+    }
+
+    private sealed class DelegateRowScorer(Func<IRowAccessor, double> fn) : IRowScorer
+    {
+        public double Score(IRowAccessor row) => fn(row);
+    }
+}

--- a/src/Sharc/Query/ScoredTopKProcessor.cs
+++ b/src/Sharc/Query/ScoredTopKProcessor.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Ram Revanur. All rights reserved.
+// Licensed under the MIT License.
+
+using Sharc.Views;
+
+namespace Sharc.Query;
+
+/// <summary>
+/// Streaming scored top-K processor. Scans a reader, scores each row via
+/// an <see cref="IRowScorer"/>, maintains a bounded max-heap of size K,
+/// and returns a materialized reader with K rows sorted ascending by score.
+/// </summary>
+/// <remarks>
+/// Rows that score worse than the current worst in the heap are never
+/// materialized (no <see cref="QueryValue"/>[] allocation). The scorer
+/// runs on the lazy <see cref="IRowAccessor"/> which only decodes accessed columns.
+/// </remarks>
+internal static class ScoredTopKProcessor
+{
+    /// <summary>
+    /// Applies streaming top-K selection with a custom scorer.
+    /// </summary>
+    internal static SharcDataReader Apply(SharcDataReader source, int k, IRowScorer scorer)
+    {
+        int fieldCount = source.FieldCount;
+        var columnNames = source.GetColumnNames();
+
+        if (k <= 0)
+        {
+            source.Dispose();
+            return new SharcDataReader(Array.Empty<QueryValue[]>(), columnNames);
+        }
+
+        // Scored heap entries: (materialized row, score)
+        var heap = new ScoredEntry[k];
+        int count = 0;
+
+        while (source.Read())
+        {
+            double score = scorer.Score(source);
+
+            if (count < k)
+            {
+                // Heap not full - always insert
+                var row = MaterializeRow(source, fieldCount);
+                heap[count] = new ScoredEntry(row, score);
+                count++;
+                SiftUp(heap, count - 1);
+            }
+            else if (score < heap[0].Score)
+            {
+                // Better than worst in heap - replace root
+                var row = MaterializeRow(source, fieldCount);
+                heap[0] = new ScoredEntry(row, score);
+                SiftDown(heap, 0, count);
+            }
+            // else: worse than heap worst - skip (no materialization)
+        }
+
+        source.Dispose();
+
+        // Extract sorted ascending by score
+        var sorted = ExtractSorted(heap, count);
+        return new SharcDataReader(sorted, columnNames);
+    }
+
+    /// <summary>
+    /// Lambda convenience overload for direct use without JitQuery.
+    /// </summary>
+    internal static SharcDataReader Apply(SharcDataReader source, int k, Func<IRowAccessor, double> scorer)
+    {
+        return Apply(source, k, new DelegateScorer(scorer));
+    }
+
+    private static QueryValue[] MaterializeRow(SharcDataReader source, int fieldCount)
+    {
+        var row = new QueryValue[fieldCount];
+        for (int i = 0; i < fieldCount; i++)
+            row[i] = QueryValueOps.MaterializeColumn(source, i);
+        return row;
+    }
+
+    /// <summary>
+    /// Extracts all entries sorted ascending by score (best first).
+    /// Uses heap-sort: repeatedly extract root (worst remaining),
+    /// write into reversed position to produce best-first order.
+    /// </summary>
+    private static QueryValue[][] ExtractSorted(ScoredEntry[] heap, int count)
+    {
+        var result = new QueryValue[count][];
+        int remaining = count;
+        int writeIndex = remaining - 1;
+
+        while (remaining > 0)
+        {
+            result[writeIndex--] = heap[0].Row;
+            remaining--;
+            if (remaining > 0)
+            {
+                heap[0] = heap[remaining];
+                SiftDown(heap, 0, remaining);
+            }
+        }
+
+        return result;
+    }
+
+    // ── Max-heap operations (worst score at root for O(1) rejection) ──
+
+    private static void SiftUp(ScoredEntry[] heap, int index)
+    {
+        while (index > 0)
+        {
+            int parent = (index - 1) / 2;
+            if (heap[index].Score > heap[parent].Score)
+            {
+                (heap[index], heap[parent]) = (heap[parent], heap[index]);
+                index = parent;
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+
+    private static void SiftDown(ScoredEntry[] heap, int index, int count)
+    {
+        while (true)
+        {
+            int left = 2 * index + 1;
+            int right = 2 * index + 2;
+            int worst = index;
+
+            if (left < count && heap[left].Score > heap[worst].Score)
+                worst = left;
+            if (right < count && heap[right].Score > heap[worst].Score)
+                worst = right;
+
+            if (worst == index) break;
+            (heap[index], heap[worst]) = (heap[worst], heap[index]);
+            index = worst;
+        }
+    }
+
+    // ── Internal types ──────────────────────────────────────────────
+
+    private struct ScoredEntry(QueryValue[] row, double score)
+    {
+        internal readonly QueryValue[] Row = row;
+        internal readonly double Score = score;
+    }
+
+    private sealed class DelegateScorer(Func<IRowAccessor, double> fn) : IRowScorer
+    {
+        public double Score(IRowAccessor row) => fn(row);
+    }
+}

--- a/src/Sharc/Query/StreamingTopNProcessor.cs
+++ b/src/Sharc/Query/StreamingTopNProcessor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Runtime.CompilerServices;
+using System.Text;
 using Sharc.Query.Intent;
 
 namespace Sharc.Query;
@@ -32,7 +33,7 @@ internal static class StreamingTopNProcessor
         if (orderBy.Count == 1)
         {
             int ordinal = QueryValueOps.ResolveOrdinal(columnNames, orderBy[0].ColumnName);
-            return ApplySingleOrderBy(
+            return ApplySingleOrderByDeferred(
                 source,
                 columnNames,
                 fieldCount,
@@ -71,8 +72,8 @@ internal static class StreamingTopNProcessor
                     int cmp = QueryValueOps.CompareValues(sortVal, root[ordinals[i]]);
                     int effectiveCmp = descending[i] ? -cmp : cmp;
                     if (effectiveCmp < 0) { rejected = false; break; } // better than root
-                    if (effectiveCmp > 0) break; // worse than root — skip
-                    // equal on this column — check next ORDER BY column
+                    if (effectiveCmp > 0) break; // worse than root - skip
+                    // equal on this column - check next ORDER BY column
                 }
                 if (rejected) continue; // skip full materialization
             }
@@ -85,7 +86,7 @@ internal static class StreamingTopNProcessor
             if (heap.TryInsert(row, out var evicted))
                 spare = evicted; // recycle evicted array
             else
-                spare = row; // not inserted — reuse this array
+                spare = row; // not inserted - reuse this array
         }
         source.Dispose();
 
@@ -93,7 +94,7 @@ internal static class StreamingTopNProcessor
         return BuildReaderWithOffset(sorted, columnNames, offsetValue);
     }
 
-    private static SharcDataReader ApplySingleOrderBy(
+    private static SharcDataReader ApplySingleOrderByDeferred(
         SharcDataReader source,
         string[] columnNames,
         int fieldCount,
@@ -102,26 +103,26 @@ internal static class StreamingTopNProcessor
         int heapSize,
         long offsetValue)
     {
-        var comparer = new SingleKeyWorstFirstComparer(sortOrdinal, descending);
-        var heap = new TopNHeap<SingleKeyWorstFirstComparer>(heapSize, comparer);
-        QueryValue[]? spare = null;
+        var comparer = new DeferredSingleKeyComparer(descending);
+        var heap = new DeferredRowHeap(heapSize, comparer);
+        DeferredRow? spare = null;
 
         while (source.Read())
         {
+            var sortValue = QueryValueOps.MaterializeColumn(source, sortOrdinal);
+
             if (heap.IsFull)
             {
                 var root = heap.PeekRoot();
-                var sortValue = QueryValueOps.MaterializeColumn(source, sortOrdinal);
-                int cmp = QueryValueOps.CompareValues(sortValue, root[sortOrdinal]);
+                int cmp = QueryValueOps.CompareValues(sortValue, root.SortKey);
                 int effectiveCmp = descending ? -cmp : cmp;
                 if (effectiveCmp >= 0)
                     continue;
             }
 
-            var row = spare ?? new QueryValue[fieldCount];
+            var row = spare ?? new DeferredRow(fieldCount);
             spare = null;
-            for (int i = 0; i < fieldCount; i++)
-                row[i] = QueryValueOps.MaterializeColumn(source, i);
+            CaptureDeferredRow(source, row, fieldCount, sortOrdinal, sortValue);
 
             if (heap.TryInsert(row, out var evicted))
                 spare = evicted;
@@ -131,7 +132,7 @@ internal static class StreamingTopNProcessor
 
         source.Dispose();
         var sorted = heap.ExtractSorted();
-        return BuildReaderWithOffset(sorted, columnNames, offsetValue);
+        return BuildReaderFromDeferred(sorted, columnNames, offsetValue, fieldCount);
     }
 
     private static SharcDataReader BuildReaderWithOffset(
@@ -152,8 +153,178 @@ internal static class StreamingTopNProcessor
         return new SharcDataReader(sorted, columnNames);
     }
 
+    private static void CaptureDeferredRow(
+        SharcDataReader source,
+        DeferredRow target,
+        int fieldCount,
+        int sortOrdinal,
+        QueryValue sortValue)
+    {
+        target.SortKey = sortValue;
+        for (int i = 0; i < fieldCount; i++)
+        {
+            ref var cell = ref target.Cells[i];
+
+            // Reuse already materialized sort key to avoid double decoding.
+            if (i == sortOrdinal)
+            {
+                CaptureFromQueryValue(ref cell, sortValue);
+                continue;
+            }
+
+            var type = source.GetColumnType(i);
+            switch (type)
+            {
+                case SharcColumnType.Integral:
+                    cell.Type = QueryValueType.Int64;
+                    cell.Int64Value = source.GetInt64(i);
+                    cell.Length = 0;
+                    break;
+
+                case SharcColumnType.Real:
+                    cell.Type = QueryValueType.Double;
+                    cell.DoubleValue = source.GetDouble(i);
+                    cell.Length = 0;
+                    break;
+
+                case SharcColumnType.Text:
+                {
+                    var utf8 = source.GetUtf8Span(i);
+                    EnsureCapacity(ref cell, utf8.Length);
+                    if (utf8.Length > 0)
+                        utf8.CopyTo(cell.Buffer!);
+                    cell.Type = QueryValueType.Text;
+                    cell.Length = utf8.Length;
+                    break;
+                }
+
+                case SharcColumnType.Blob:
+                {
+                    var blob = source.GetBlobSpan(i);
+                    EnsureCapacity(ref cell, blob.Length);
+                    if (blob.Length > 0)
+                        blob.CopyTo(cell.Buffer!);
+                    cell.Type = QueryValueType.Blob;
+                    cell.Length = blob.Length;
+                    break;
+                }
+
+                default:
+                    cell.Type = QueryValueType.Null;
+                    cell.Length = 0;
+                    break;
+            }
+        }
+    }
+
+    private static void CaptureFromQueryValue(ref DeferredCell cell, QueryValue value)
+    {
+        switch (value.Type)
+        {
+            case QueryValueType.Int64:
+                cell.Type = QueryValueType.Int64;
+                cell.Int64Value = value.AsInt64();
+                cell.Length = 0;
+                return;
+
+            case QueryValueType.Double:
+                cell.Type = QueryValueType.Double;
+                cell.DoubleValue = value.AsDouble();
+                cell.Length = 0;
+                return;
+
+            case QueryValueType.Text:
+            {
+                var utf8 = Encoding.UTF8.GetBytes(value.AsString());
+                EnsureCapacity(ref cell, utf8.Length);
+                if (utf8.Length > 0)
+                    utf8.CopyTo(cell.Buffer!, 0);
+                cell.Type = QueryValueType.Text;
+                cell.Length = utf8.Length;
+                return;
+            }
+
+            case QueryValueType.Blob:
+            {
+                var blob = value.AsBlob();
+                EnsureCapacity(ref cell, blob.Length);
+                if (blob.Length > 0)
+                    blob.CopyTo(cell.Buffer!, 0);
+                cell.Type = QueryValueType.Blob;
+                cell.Length = blob.Length;
+                return;
+            }
+
+            default:
+                cell.Type = QueryValueType.Null;
+                cell.Length = 0;
+                return;
+        }
+    }
+
+    private static void EnsureCapacity(ref DeferredCell cell, int length)
+    {
+        if (length == 0)
+        {
+            if (cell.Buffer != null)
+                cell.Buffer.AsSpan().Clear();
+            return;
+        }
+
+        if (cell.Buffer == null || cell.Buffer.Length < length)
+            cell.Buffer = new byte[length];
+    }
+
+    private static SharcDataReader BuildReaderFromDeferred(
+        DeferredRow[] sorted,
+        string[] columnNames,
+        long offsetValue,
+        int fieldCount)
+    {
+        int skip = offsetValue > 0
+            ? (int)Math.Min(offsetValue, sorted.Length)
+            : 0;
+
+        int outputCount = Math.Max(0, sorted.Length - skip);
+        var output = new QueryValue[outputCount][];
+        for (int i = 0; i < outputCount; i++)
+            output[i] = MaterializeDeferredRow(sorted[skip + i], fieldCount);
+
+        return new SharcDataReader(output, columnNames);
+    }
+
+    private static QueryValue[] MaterializeDeferredRow(DeferredRow row, int fieldCount)
+    {
+        var values = new QueryValue[fieldCount];
+        for (int i = 0; i < fieldCount; i++)
+        {
+            ref var cell = ref row.Cells[i];
+            values[i] = cell.Type switch
+            {
+                QueryValueType.Int64 => QueryValue.FromInt64(cell.Int64Value),
+                QueryValueType.Double => QueryValue.FromDouble(cell.DoubleValue),
+                QueryValueType.Text => QueryValue.FromString(
+                    cell.Length == 0 ? string.Empty : Encoding.UTF8.GetString(cell.Buffer!, 0, cell.Length)),
+                QueryValueType.Blob => QueryValue.FromBlob(
+                    cell.Length == 0 ? Array.Empty<byte>() : CopyExact(cell.Buffer!, cell.Length)),
+                _ => QueryValue.Null,
+            };
+        }
+        return values;
+    }
+
+    private static byte[] CopyExact(byte[] source, int length)
+    {
+        if (length == source.Length)
+            return source;
+
+        var copy = new byte[length];
+        Buffer.BlockCopy(source, 0, copy, 0, length);
+        return copy;
+    }
+
     /// <summary>
-    /// Struct comparer for the TopN heap — enables JIT specialization (no delegate/closure alloc).
+    /// Struct comparer for the TopN heap - enables JIT specialization (no delegate/closure alloc).
     /// Orders rows so the "worst" compares as positive (max-heap root = worst retained row).
     /// </summary>
     internal readonly struct WorstFirstComparer : IComparer<QueryValue[]>
@@ -200,5 +371,142 @@ internal static class StreamingTopNProcessor
             int cmp = QueryValueOps.CompareValues(a![_ordinal], b![_ordinal]);
             return _descending ? -cmp : cmp;
         }
+    }
+
+    private sealed class DeferredRowHeap
+    {
+        private readonly DeferredRow[] _heap;
+        private readonly int _capacity;
+        private readonly DeferredSingleKeyComparer _comparer;
+        private int _count;
+
+        internal DeferredRowHeap(int capacity, DeferredSingleKeyComparer comparer)
+        {
+            _capacity = capacity;
+            _comparer = comparer;
+            _heap = new DeferredRow[capacity];
+            _count = 0;
+        }
+
+        internal bool IsFull => _count >= _capacity;
+
+        internal DeferredRow PeekRoot() => _heap[0];
+
+        internal bool TryInsert(DeferredRow row, out DeferredRow? evicted)
+        {
+            evicted = null;
+            if (_count < _capacity)
+            {
+                _heap[_count] = row;
+                _count++;
+                SiftUp(_count - 1);
+                return true;
+            }
+
+            if (_comparer.Compare(row, _heap[0]) < 0)
+            {
+                evicted = _heap[0];
+                _heap[0] = row;
+                SiftDown(0);
+                return true;
+            }
+
+            return false;
+        }
+
+        internal DeferredRow[] ExtractSorted()
+        {
+            var result = new DeferredRow[_count];
+            int remaining = _count;
+            int writeIndex = remaining - 1;
+            while (remaining > 0)
+            {
+                result[writeIndex--] = _heap[0];
+                remaining--;
+                if (remaining > 0)
+                {
+                    _heap[0] = _heap[remaining];
+                    _heap[remaining] = null!;
+                    SiftDownRange(0, remaining);
+                }
+            }
+            return result;
+        }
+
+        private void SiftUp(int index)
+        {
+            while (index > 0)
+            {
+                int parent = (index - 1) / 2;
+                if (_comparer.Compare(_heap[index], _heap[parent]) > 0)
+                {
+                    (_heap[index], _heap[parent]) = (_heap[parent], _heap[index]);
+                    index = parent;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        private void SiftDown(int index) => SiftDownRange(index, _count);
+
+        private void SiftDownRange(int index, int count)
+        {
+            while (true)
+            {
+                int left = 2 * index + 1;
+                int right = 2 * index + 2;
+                int worst = index;
+
+                if (left < count && _comparer.Compare(_heap[left], _heap[worst]) > 0)
+                    worst = left;
+                if (right < count && _comparer.Compare(_heap[right], _heap[worst]) > 0)
+                    worst = right;
+
+                if (worst == index) break;
+                (_heap[index], _heap[worst]) = (_heap[worst], _heap[index]);
+                index = worst;
+            }
+        }
+    }
+
+    private readonly struct DeferredSingleKeyComparer : IComparer<DeferredRow>
+    {
+        private readonly bool _descending;
+
+        internal DeferredSingleKeyComparer(bool descending)
+        {
+            _descending = descending;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(DeferredRow? a, DeferredRow? b)
+        {
+            int cmp = QueryValueOps.CompareValues(a!.SortKey, b!.SortKey);
+            return _descending ? -cmp : cmp;
+        }
+    }
+
+    private sealed class DeferredRow
+    {
+        internal readonly DeferredCell[] Cells;
+        internal QueryValue SortKey;
+
+        internal DeferredRow(int fieldCount)
+        {
+            Cells = new DeferredCell[fieldCount];
+            SortKey = QueryValue.Null;
+        }
+    }
+
+    private struct DeferredCell
+    {
+        internal QueryValueType Type;
+        internal long Int64Value;
+        internal double DoubleValue;
+        internal byte[]? Buffer;
+        internal int Length;
     }
 }

--- a/src/Sharc/SharcDataReader.cs
+++ b/src/Sharc/SharcDataReader.cs
@@ -11,6 +11,7 @@ using Sharc.Core.IO;
 using Sharc.Core.Schema;
 using Sharc.Core.Query;
 using Sharc.Query;
+using Sharc.Views;
 
 namespace Sharc;
 
@@ -29,7 +30,7 @@ namespace Sharc;
 /// }
 /// </code>
 /// </remarks>
-public sealed partial class SharcDataReader : IDisposable
+public sealed partial class SharcDataReader : IRowAccessor, IDisposable
 {
     // ══════════════════════════════════════════════════════════════════════
     // FIELD LAYOUT & FILE ORGANIZATION

--- a/tests/Sharc.IntegrationTests/TopKIntegrationTests.cs
+++ b/tests/Sharc.IntegrationTests/TopKIntegrationTests.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Ram Revanur. All rights reserved.
+// Licensed under the MIT License.
+
+using Sharc.IntegrationTests.Helpers;
+using Sharc.Views;
+using Xunit;
+
+namespace Sharc.IntegrationTests;
+
+public sealed class TopKIntegrationTests
+{
+    /// <summary>Euclidean distance from a target point.</summary>
+    private sealed class DistanceScorer(double cx, double cy) : IRowScorer
+    {
+        public double Score(IRowAccessor row) =>
+            Math.Sqrt(Math.Pow(row.GetDouble(0) - cx, 2) + Math.Pow(row.GetDouble(1) - cy, 2));
+    }
+
+    [Fact]
+    public void TopK_WithDatabase_EndToEnd()
+    {
+        // Create table with x, y columns and 100 points
+        var data = TestDatabaseFactory.CreateDatabaseWith(conn =>
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "CREATE TABLE points (id INTEGER PRIMARY KEY, x REAL, y REAL)";
+            cmd.ExecuteNonQuery();
+
+            for (int i = 0; i < 100; i++)
+            {
+                cmd.CommandText = $"INSERT INTO points (x, y) VALUES ({i}.0, {i}.0)";
+                cmd.ExecuteNonQuery();
+            }
+        });
+
+        using var db = SharcDatabase.OpenMemory(data);
+        var jit = db.Jit("points");
+
+        // Find 5 nearest to origin — project x, y
+        using var reader = jit.TopK(5, new DistanceScorer(0, 0), "x", "y");
+
+        var results = new List<(double x, double y)>();
+        while (reader.Read())
+            results.Add((reader.GetDouble(0), reader.GetDouble(1)));
+
+        Assert.Equal(5, results.Count);
+
+        // Should be (0,0), (1,1), (2,2), (3,3), (4,4) sorted by distance
+        for (int i = 0; i < 5; i++)
+        {
+            Assert.Equal((double)i, results[i].x);
+            Assert.Equal((double)i, results[i].y);
+        }
+    }
+
+    [Fact]
+    public void TopK_WithFilterChain_FiltersFirst()
+    {
+        // Create table with 100 points, filter to x >= 10, then TopK
+        var data = TestDatabaseFactory.CreateDatabaseWith(conn =>
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "CREATE TABLE points (id INTEGER PRIMARY KEY, x REAL, y REAL)";
+            cmd.ExecuteNonQuery();
+
+            for (int i = 0; i < 100; i++)
+            {
+                cmd.CommandText = $"INSERT INTO points (x, y) VALUES ({i}.0, {i}.0)";
+                cmd.ExecuteNonQuery();
+            }
+        });
+
+        using var db = SharcDatabase.OpenMemory(data);
+        var jit = db.Jit("points");
+
+        // Filter: only x >= 10, then find 3 nearest to (10, 10)
+        jit.Where(FilterStar.Column("x").Gte(10.0));
+        using var reader = jit.TopK(3, new DistanceScorer(10, 10), "x", "y");
+
+        var results = new List<(double x, double y)>();
+        while (reader.Read())
+            results.Add((reader.GetDouble(0), reader.GetDouble(1)));
+
+        Assert.Equal(3, results.Count);
+
+        // (10,10) is distance 0, (11,11) is ~1.41, (12,12) is ~2.83
+        Assert.Equal(10.0, results[0].x);
+        Assert.Equal(10.0, results[0].y);
+        Assert.Equal(11.0, results[1].x);
+        Assert.Equal(12.0, results[2].x);
+    }
+
+    [Fact]
+    public void TopK_LambdaOverload_WithDatabase()
+    {
+        var data = TestDatabaseFactory.CreateDatabaseWith(conn =>
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "CREATE TABLE points (id INTEGER PRIMARY KEY, x REAL, y REAL)";
+            cmd.ExecuteNonQuery();
+
+            for (int i = 0; i < 20; i++)
+            {
+                cmd.CommandText = $"INSERT INTO points (x, y) VALUES ({i}.0, {i}.0)";
+                cmd.ExecuteNonQuery();
+            }
+        });
+
+        using var db = SharcDatabase.OpenMemory(data);
+        var jit = db.Jit("points");
+
+        // Lambda scorer: distance from (5, 5)
+        using var reader = jit.TopK(3,
+            row => Math.Sqrt(Math.Pow(row.GetDouble(0) - 5, 2) + Math.Pow(row.GetDouble(1) - 5, 2)),
+            "x", "y");
+
+        var results = new List<(double x, double y)>();
+        while (reader.Read())
+            results.Add((reader.GetDouble(0), reader.GetDouble(1)));
+
+        Assert.Equal(3, results.Count);
+        // Nearest to (5,5): (5,5) at d=0, (4,4) at d=~1.41, (6,6) at d=~1.41
+        Assert.Equal(5.0, results[0].x);
+    }
+
+    [Fact]
+    public void TopK_KZero_Throws()
+    {
+        var data = TestDatabaseFactory.CreateDatabaseWith(conn =>
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY, val REAL)";
+            cmd.ExecuteNonQuery();
+        });
+
+        using var db = SharcDatabase.OpenMemory(data);
+        var jit = db.Jit("t");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            jit.TopK(0, new DistanceScorer(0, 0), "val"));
+    }
+
+    [Fact]
+    public void TopK_NullScorer_Throws()
+    {
+        var data = TestDatabaseFactory.CreateDatabaseWith(conn =>
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY, val REAL)";
+            cmd.ExecuteNonQuery();
+        });
+
+        using var db = SharcDatabase.OpenMemory(data);
+        var jit = db.Jit("t");
+
+        Assert.Throws<ArgumentNullException>(() =>
+            jit.TopK(1, (IRowScorer)null!, "val"));
+    }
+}

--- a/tests/Sharc.Tests/Query/ScoredTopKProcessorTests.cs
+++ b/tests/Sharc.Tests/Query/ScoredTopKProcessorTests.cs
@@ -1,0 +1,213 @@
+// Copyright (c) Ram Revanur. All rights reserved.
+// Licensed under the MIT License.
+
+using Sharc.Query;
+using Sharc.Views;
+using Xunit;
+
+namespace Sharc.Tests.Query;
+
+public class ScoredTopKProcessorTests
+{
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    /// <summary>Builds a materialized reader from (x, y) double pairs.</summary>
+    private static SharcDataReader MakeReader(params (double x, double y)[] points)
+    {
+        var rows = new QueryValue[points.Length][];
+        for (int i = 0; i < points.Length; i++)
+            rows[i] = [QueryValue.FromDouble(points[i].x), QueryValue.FromDouble(points[i].y)];
+        return new SharcDataReader(rows, ["x", "y"]);
+    }
+
+    /// <summary>Builds a materialized reader from integer values.</summary>
+    private static SharcDataReader MakeIntReader(params long[] values)
+    {
+        var rows = new QueryValue[values.Length][];
+        for (int i = 0; i < values.Length; i++)
+            rows[i] = [QueryValue.FromInt64(values[i])];
+        return new SharcDataReader(rows, ["val"]);
+    }
+
+    /// <summary>Scorer: Euclidean distance from a target (cx, cy).</summary>
+    private sealed class DistanceScorer(double cx, double cy) : IRowScorer
+    {
+        public double Score(IRowAccessor row) =>
+            Math.Sqrt(Math.Pow(row.GetDouble(0) - cx, 2) + Math.Pow(row.GetDouble(1) - cy, 2));
+    }
+
+    /// <summary>Scorer: absolute value of an integer column.</summary>
+    private sealed class AbsScorer : IRowScorer
+    {
+        public double Score(IRowAccessor row) => Math.Abs(row.GetInt64(0));
+    }
+
+    // ── Core behavior ───────────────────────────────────────────────
+
+    [Fact]
+    public void Apply_ReturnsKNearestByScore()
+    {
+        // 5 points, find 2 nearest to origin (0,0)
+        var reader = MakeReader(
+            (10, 10),  // distance ~14.14
+            (1, 1),    // distance ~1.41  -- nearest
+            (5, 5),    // distance ~7.07
+            (2, 0),    // distance  2.00  -- 2nd nearest
+            (8, 8));   // distance ~11.31
+
+        var result = ScoredTopKProcessor.Apply(reader, 2, new DistanceScorer(0, 0));
+
+        var rows = ReadAll(result);
+        Assert.Equal(2, rows.Count);
+        // Should be (1,1) then (2,0) - sorted ascending by distance
+        Assert.Equal(1.0, rows[0][0].AsDouble());
+        Assert.Equal(1.0, rows[0][1].AsDouble());
+        Assert.Equal(2.0, rows[1][0].AsDouble());
+        Assert.Equal(0.0, rows[1][1].AsDouble());
+    }
+
+    [Fact]
+    public void Apply_ResultsSortedAscendingByScore()
+    {
+        var reader = MakeIntReader(50, -3, 10, -1, 20, 2);
+        var result = ScoredTopKProcessor.Apply(reader, 4, new AbsScorer());
+
+        var rows = ReadAll(result);
+        Assert.Equal(4, rows.Count);
+        // Sorted by |val|: |-1|=1, |2|=2, |-3|=3, |10|=10
+        Assert.Equal(-1, rows[0][0].AsInt64());
+        Assert.Equal(2, rows[1][0].AsInt64());
+        Assert.Equal(-3, rows[2][0].AsInt64());
+        Assert.Equal(10, rows[3][0].AsInt64());
+    }
+
+    [Fact]
+    public void Apply_KGreaterThanRows_ReturnsAll()
+    {
+        var reader = MakeIntReader(5, 3, 1);
+        var result = ScoredTopKProcessor.Apply(reader, 50, new AbsScorer());
+
+        var rows = ReadAll(result);
+        Assert.Equal(3, rows.Count);
+        // Sorted ascending by |val|: 1, 3, 5
+        Assert.Equal(1, rows[0][0].AsInt64());
+        Assert.Equal(3, rows[1][0].AsInt64());
+        Assert.Equal(5, rows[2][0].AsInt64());
+    }
+
+    [Fact]
+    public void Apply_KEqualsOne_ReturnsBest()
+    {
+        var reader = MakeReader(
+            (10, 10),
+            (1, 0),   // closest to origin
+            (5, 5));
+
+        var result = ScoredTopKProcessor.Apply(reader, 1, new DistanceScorer(0, 0));
+
+        var rows = ReadAll(result);
+        Assert.Single(rows);
+        Assert.Equal(1.0, rows[0][0].AsDouble());
+        Assert.Equal(0.0, rows[0][1].AsDouble());
+    }
+
+    [Fact]
+    public void Apply_EmptySource_ReturnsEmpty()
+    {
+        var reader = new SharcDataReader(Array.Empty<QueryValue[]>(), ["x", "y"]);
+        var result = ScoredTopKProcessor.Apply(reader, 10, new DistanceScorer(0, 0));
+
+        var rows = ReadAll(result);
+        Assert.Empty(rows);
+    }
+
+    [Fact]
+    public void Apply_AllSameScore_ReturnsK()
+    {
+        // All at distance 5 from origin
+        var reader = MakeReader((3, 4), (0, 5), (5, 0), (4, 3));
+        var result = ScoredTopKProcessor.Apply(reader, 2, new DistanceScorer(0, 0));
+
+        var rows = ReadAll(result);
+        Assert.Equal(2, rows.Count);
+    }
+
+    [Fact]
+    public void Apply_LambdaOverload_Works()
+    {
+        var reader = MakeIntReader(30, 10, 20, 5);
+        var result = ScoredTopKProcessor.Apply(reader, 2,
+            row => (double)row.GetInt64(0));
+
+        var rows = ReadAll(result);
+        Assert.Equal(2, rows.Count);
+        // Two lowest: 5, 10
+        Assert.Equal(5, rows[0][0].AsInt64());
+        Assert.Equal(10, rows[1][0].AsInt64());
+    }
+
+    [Fact]
+    public void Apply_PreservesAllColumns()
+    {
+        // Ensure all columns are materialized, not just scored ones
+        var rows = new QueryValue[3][];
+        rows[0] = [QueryValue.FromDouble(5), QueryValue.FromDouble(5), QueryValue.FromString("far")];
+        rows[1] = [QueryValue.FromDouble(1), QueryValue.FromDouble(0), QueryValue.FromString("near")];
+        rows[2] = [QueryValue.FromDouble(3), QueryValue.FromDouble(3), QueryValue.FromString("mid")];
+        var reader = new SharcDataReader(rows, ["x", "y", "label"]);
+
+        var result = ScoredTopKProcessor.Apply(reader, 2, new DistanceScorer(0, 0));
+
+        var output = ReadAll(result);
+        Assert.Equal(2, output.Count);
+        Assert.Equal("near", output[0][2].AsString());
+        Assert.Equal("mid", output[1][2].AsString());
+    }
+
+    [Fact]
+    public void Apply_LargeDataset_ReturnsCorrectTopK()
+    {
+        // 100 points, find 5 nearest to origin
+        var points = new (double x, double y)[100];
+        for (int i = 0; i < 100; i++)
+            points[i] = (i, i); // distances: 0, sqrt(2), 2*sqrt(2), ...
+
+        var reader = MakeReader(points);
+        var result = ScoredTopKProcessor.Apply(reader, 5, new DistanceScorer(0, 0));
+
+        var output = ReadAll(result);
+        Assert.Equal(5, output.Count);
+
+        // Should be (0,0), (1,1), (2,2), (3,3), (4,4)
+        for (int i = 0; i < 5; i++)
+        {
+            Assert.Equal((double)i, output[i][0].AsDouble());
+            Assert.Equal((double)i, output[i][1].AsDouble());
+        }
+    }
+
+    // ── Helper ──────────────────────────────────────────────────────
+
+    private static List<QueryValue[]> ReadAll(SharcDataReader reader)
+    {
+        var list = new List<QueryValue[]>();
+        while (reader.Read())
+        {
+            var row = new QueryValue[reader.FieldCount];
+            for (int i = 0; i < reader.FieldCount; i++)
+            {
+                row[i] = reader.GetColumnType(i) switch
+                {
+                    SharcColumnType.Integral => QueryValue.FromInt64(reader.GetInt64(i)),
+                    SharcColumnType.Real => QueryValue.FromDouble(reader.GetDouble(i)),
+                    SharcColumnType.Text => QueryValue.FromString(reader.GetString(i)),
+                    SharcColumnType.Blob => QueryValue.FromBlob(reader.GetBlob(i)),
+                    _ => QueryValue.Null,
+                };
+            }
+            list.Add(row);
+        }
+        reader.Dispose();
+        return list;
+    }
+}

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -64,4 +64,4 @@ All operations go through the B-tree layer, which reads SQLite pages directly fr
 | [Graph DB Comparison](../docs/GRAPH_DB_COMPARISON.md) | Sharc vs SurrealDB, ArangoDB, Neo4j |
 | [Vector Search Guide](../docs/VECTOR_SEARCH.md) | Embedding storage, RAG, semantic cache patterns |
 | [Alternatives](../docs/ALTERNATIVES.md) | Honest comparison vs SQLite, LiteDB, DuckDB |
-| [Samples](../samples/) | 8 runnable sample projects including API comparison |
+| [Samples](../samples/) | 12 runnable sample projects including API comparison and TopK scoring |

--- a/wiki/Querying-Data.md
+++ b/wiki/Querying-Data.md
@@ -46,6 +46,58 @@ See [Trust Layer](Trust-Layer) for agent setup.
 
 Sharc caches compiled query plans (filter delegates, projection arrays, table metadata) for repeated queries with the same structure. The cache is keyed by `QueryIntent`, so parameterized queries benefit from plan reuse automatically.
 
+## Streaming Top-K with Custom Scoring
+
+Use `JitQuery.TopK()` to find the K best-scoring rows without materializing the entire result set. The scorer runs on each row after all filters have been applied. Rows that score worse than the current worst in the bounded heap are never materialized, keeping memory at O(K).
+
+Lower scores rank higher (natural for distance-based scoring).
+
+### With a reusable scorer class
+
+```csharp
+// Implement IRowScorer for reusable, stateful scoring
+sealed class DistanceScorer(double cx, double cy) : IRowScorer
+{
+    public double Score(IRowAccessor row)
+    {
+        double dx = row.GetDouble(0) - cx;
+        double dy = row.GetDouble(1) - cy;
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+}
+
+// Filter first (B-tree accelerated), then score survivors
+var jit = db.Jit("points");
+jit.Where(FilterStar.Column("x").Between(cx - r, cx + r));
+jit.Where(FilterStar.Column("y").Between(cy - r, cy + r));
+using var reader = jit.TopK(20, new DistanceScorer(cx, cy), "x", "y", "id");
+
+while (reader.Read())
+{
+    double x = reader.GetDouble(0);
+    double y = reader.GetDouble(1);
+    long id = reader.GetInt64(2);
+}
+```
+
+### With a lambda scorer
+
+```csharp
+// One-off scoring without implementing IRowScorer
+using var reader = jit.TopK(10,
+    row => Math.Abs(row.GetDouble(0) - target),
+    "value", "label");
+```
+
+### Key points
+
+- `TopK()` is a **terminal method** (like `Query()`) that executes immediately
+- Composes with all existing filters: `FilterStar`, `IRowAccessEvaluator`, `WithLimit`
+- Only K rows are materialized; rejected rows incur zero allocation
+- Results are sorted ascending by score (best first)
+
+See the [`PrimeExample`](../samples/PrimeExample/) sample for a complete spatial query walkthrough.
+
 ## Supported Syntax
 
 Sharq supports:
@@ -55,4 +107,5 @@ Sharq supports:
 - Parameterized values (`$param`)
 - `JOIN` (inner joins via the query pipeline)
 - `ORDER BY` (via cursor-based sorting)
+- `TopK` with custom scoring (via `JitQuery.TopK()`)
 - Table and column name resolution (case-insensitive)


### PR DESCRIPTION
….2.0)

Add IRowScorer interface and JitQuery.TopK() terminal method for streaming top-K selection with bounded heap. Filters narrow the search space first, then the scorer ranks survivors — rows below the heap threshold are never materialized, keeping memory at O(K).

- IRowScorer: public interface with double Score(IRowAccessor row)
- JitQuery.TopK(): terminal method (zero new fields on JitQuery)
- ScoredTopKProcessor: internal max-heap with fast rejection
- SharcDataReader now implements IRowAccessor explicitly
- PrimeExample sample: spatial nearest-neighbor with 10K spiral points
- 14 new tests (9 unit + 5 integration), 3621 total passing
- Wiki updated: Querying-Data, Performance-Guide, Home, samples/README
- Version bumped to 1.2.0