### PR TITLE
1.2.66

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+# Summary
+
+Describe what changed and why.
+
+# Validation
+
+- [ ] `dotnet build --configuration Release`
+- [ ] `dotnet test --configuration Release`
+
+# Release Checklist (Required for PRs into `main`)
+
+- [ ] Updated `README.md` with user-facing package/API changes
+- [ ] Added release notes in `CHANGELOG.md` under `## [1.2.<PR_NUMBER>] - YYYY-MM-DD`
+- [ ] Verified NuGet publish workflow can pack all required packages (`Sharc`, `Sharc.Core`, `Sharc.Query`, `Sharc.Crypto`, `Sharc.Graph.Surface`, `Sharc.Graph`, `Sharc.Vector`, `Sharc.Arc`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,43 @@ permissions:
   contents: read
 
 jobs:
+  release-readiness:
+    name: Release Readiness
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Enforce release docs and notes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          echo "Changed files in PR:"
+          echo "$changed_files"
+
+          require_changed_file() {
+            local required_path="$1"
+            if ! grep -Fxq "$required_path" <<<"$changed_files"; then
+              echo "::error::Release PRs to main must update ${required_path}."
+              exit 1
+            fi
+          }
+
+          require_changed_file "README.md"
+          require_changed_file "CHANGELOG.md"
+
+          if ! grep -Eq "^## \\[1\\.2\\.(${PR_NUMBER}|PR-NUM)\\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md must include release heading '## [1.2.${PR_NUMBER}]' (or placeholder '## [1.2.PR-NUM]')."
+            exit 1
+          fi
+
   build-and-test:
     name: Build & Test
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [main]
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version to publish (e.g. 1.2.65)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -11,7 +17,7 @@ permissions:
 jobs:
   build-and-test:
     name: Build & Test
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +45,8 @@ jobs:
     name: Pack & Publish
     needs: build-and-test
     runs-on: ubuntu-latest
+    env:
+      PACKAGE_DIR: artifacts/nuget
     steps:
       - uses: actions/checkout@v4
 
@@ -53,37 +61,45 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          VERSION="1.2.${PR_NUMBER}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ github.event.inputs.version }}"
+            echo "Publishing version: $VERSION (manual dispatch)"
+          else
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            VERSION="1.2.${PR_NUMBER}"
+            echo "Publishing version: $VERSION (from PR #$PR_NUMBER)"
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Publishing version: $VERSION (from PR #$PR_NUMBER)"
 
       - name: Build Release
         run: dotnet build --configuration Release /p:Version=${{ steps.version.outputs.version }}
 
-      - name: Pack Sharc.Core
-        run: dotnet pack src/Sharc.Core/Sharc.Core.csproj --configuration Release --no-build -o dist /p:Version=${{ steps.version.outputs.version }}
+      - name: Prepare package output directory
+        run: mkdir -p "${{ env.PACKAGE_DIR }}"
 
       - name: Pack Sharc.Query
-        run: dotnet pack src/Sharc.Query/Sharc.Query.csproj --configuration Release --no-build -o dist /p:Version=${{ steps.version.outputs.version }}
+        run: dotnet pack src/Sharc.Query/Sharc.Query.csproj --configuration Release --no-build -o "${{ env.PACKAGE_DIR }}" /p:Version=${{ steps.version.outputs.version }}
+
+      - name: Pack Sharc.Core
+        run: dotnet pack src/Sharc.Core/Sharc.Core.csproj --configuration Release --no-build -o "${{ env.PACKAGE_DIR }}" /p:Version=${{ steps.version.outputs.version }}
 
       - name: Pack Sharc.Crypto
-        run: dotnet pack src/Sharc.Crypto/Sharc.Crypto.csproj --configuration Release --no-build -o dist /p:Version=${{ steps.version.outputs.version }}
+        run: dotnet pack src/Sharc.Crypto/Sharc.Crypto.csproj --configuration Release --no-build -o "${{ env.PACKAGE_DIR }}" /p:Version=${{ steps.version.outputs.version }}
 
       - name: Pack Sharc.Graph.Surface
-        run: dotnet pack src/Sharc.Graph.Surface/Sharc.Graph.Surface.csproj --configuration Release --no-build -o dist /p:Version=${{ steps.version.outputs.version }}
+        run: dotnet pack src/Sharc.Graph.Surface/Sharc.Graph.Surface.csproj --configuration Release --no-build -o "${{ env.PACKAGE_DIR }}" /p:Version=${{ steps.version.outputs.version }}
 
       - name: Pack Sharc
-        run: dotnet pack src/Sharc/Sharc.csproj --configuration Release --no-build -o dist /p:Version=${{ steps.version.outputs.version }}
+        run: dotnet pack src/Sharc/Sharc.csproj --configuration Release --no-build -o "${{ env.PACKAGE_DIR }}" /p:Version=${{ steps.version.outputs.version }}
 
       - name: Pack Sharc.Graph
-        run: dotnet pack src/Sharc.Graph/Sharc.Graph.csproj --configuration Release --no-build -o dist /p:Version=${{ steps.version.outputs.version }}
+        run: dotnet pack src/Sharc.Graph/Sharc.Graph.csproj --configuration Release --no-build -o "${{ env.PACKAGE_DIR }}" /p:Version=${{ steps.version.outputs.version }}
 
       - name: Pack Sharc.Vector
-        run: dotnet pack src/Sharc.Vector/Sharc.Vector.csproj --configuration Release --no-build -o dist /p:Version=${{ steps.version.outputs.version }}
+        run: dotnet pack src/Sharc.Vector/Sharc.Vector.csproj --configuration Release --no-build -o "${{ env.PACKAGE_DIR }}" /p:Version=${{ steps.version.outputs.version }}
 
       - name: Pack Sharc.Arc
-        run: dotnet pack src/Sharc.Arc/Sharc.Arc.csproj --configuration Release --no-build -o dist /p:Version=${{ steps.version.outputs.version }}
+        run: dotnet pack src/Sharc.Arc/Sharc.Arc.csproj --configuration Release --no-build -o "${{ env.PACKAGE_DIR }}" /p:Version=${{ steps.version.outputs.version }}
 
       - name: Verify package artifacts
         env:
@@ -91,8 +107,8 @@ jobs:
         run: |
           set -euo pipefail
           packages=(
-            "Sharc.Core"
             "Sharc.Query"
+            "Sharc.Core"
             "Sharc.Crypto"
             "Sharc"
             "Sharc.Graph.Surface"
@@ -101,7 +117,7 @@ jobs:
             "Sharc.Arc"
           )
           for package in "${packages[@]}"; do
-            artifact="dist/${package}.${VERSION}.nupkg"
+            artifact="${PACKAGE_DIR}/${package}.${VERSION}.nupkg"
             if [[ ! -f "$artifact" ]]; then
               echo "::error::Missing package artifact: $artifact"
               exit 1
@@ -114,8 +130,8 @@ jobs:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           set -euo pipefail
-          for package in "Sharc.Core" "Sharc.Query" "Sharc.Crypto"; do
-            dotnet nuget push "dist/${package}.${VERSION}.nupkg" \
+          for package in "Sharc.Query" "Sharc.Core" "Sharc.Crypto"; do
+            dotnet nuget push "${PACKAGE_DIR}/${package}.${VERSION}.nupkg" \
               --api-key "$NUGET_API_KEY" \
               --source https://api.nuget.org/v3/index.json \
               --skip-duplicate
@@ -144,7 +160,7 @@ jobs:
             return 1
           }
 
-          for package in "Sharc.Core" "Sharc.Query" "Sharc.Crypto"; do
+          for package in "Sharc.Query" "Sharc.Core" "Sharc.Crypto"; do
             wait_for_package_version "$package"
           done
 
@@ -154,7 +170,7 @@ jobs:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           set -euo pipefail
-          dotnet nuget push "dist/Sharc.${VERSION}.nupkg" \
+          dotnet nuget push "${PACKAGE_DIR}/Sharc.${VERSION}.nupkg" \
             --api-key "$NUGET_API_KEY" \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
@@ -182,7 +198,7 @@ jobs:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           set -euo pipefail
-          dotnet nuget push "dist/Sharc.Graph.Surface.${VERSION}.nupkg" \
+          dotnet nuget push "${PACKAGE_DIR}/Sharc.Graph.Surface.${VERSION}.nupkg" \
             --api-key "$NUGET_API_KEY" \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
@@ -211,7 +227,7 @@ jobs:
         run: |
           set -euo pipefail
           for package in "Sharc.Graph" "Sharc.Vector" "Sharc.Arc"; do
-            dotnet nuget push "dist/${package}.${VERSION}.nupkg" \
+            dotnet nuget push "${PACKAGE_DIR}/${package}.${VERSION}.nupkg" \
               --api-key "$NUGET_API_KEY" \
               --source https://api.nuget.org/v3/index.json \
               --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ obj/
 artifacts/
 BenchmarkDotNet.Artifacts/
 TestResults/
+nupkgs/
+dist/
 nul
 .claude/
 secrets/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.PR-NUM] - 2026-02-26
+
+### Fixed
+- NuGet publish pipeline now packs and publishes `Sharc.Core` together with the `Sharc` meta package dependency chain.
+- `CreateReader(..., SharcFilter[] filters)` now uses index planning for sargable legacy filters instead of always forcing a table scan.
+
+### Changed
+- NuGet package staging moved to `artifacts/nuget` (ignored folder) to avoid root-level package artifacts.
+- Release PR policy formalized: PRs to `main` must include `README.md` and `CHANGELOG.md` updates.
+
 ## [1.0.0-beta.1] - 2026-02-16
 
 ### Core Engine

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,19 @@ tools/Sharc.Index/            Git history → SQLite CLI
 4. Ensure the build has zero warnings: `dotnet build --configuration Release`
 5. Keep PRs focused — one feature or fix per PR
 6. Write a clear PR description explaining **what** and **why**
+7. For PRs into `main` (release PRs), update both `README.md` and `CHANGELOG.md`
+8. Add release notes heading in `CHANGELOG.md` as `## [1.2.<PR_NUMBER>] - YYYY-MM-DD`
+
+## NuGet Packaging Hygiene
+
+- Do not generate package artifacts in the repo root.
+- Use an ignored output folder for local packing:
+
+```bash
+dotnet pack src/Sharc/Sharc.csproj -c Release -o artifacts/nuget
+```
+
+- CI publish also stages packages in `artifacts/nuget`.
 
 ## What NOT to Do
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,9 +42,9 @@
     <RepositoryType>git</RepositoryType>
 
     <!-- Assembly metadata -->
-    <AssemblyVersion>1.2.1.0</AssemblyVersion>
-    <FileVersion>1.2.1.0</FileVersion>
-    <Version>1.2.1</Version>
+    <AssemblyVersion>1.2.65.0</AssemblyVersion>
+    <FileVersion>1.2.65.0</FileVersion>
+    <Version>1.2.65</Version>
 
     <!-- Optimization for WASM/Size -->
     <IsTrimmable>true</IsTrimmable>

--- a/README.md
+++ b/README.md
@@ -429,6 +429,14 @@ dotnet run -c Release --project bench/Sharc.Comparisons -- --filter *FocusedPerf
 dotnet script ./samples/run-all.csx -- --build-only     # Validate all samples compile (requires dotnet-script)
 ```
 
+## Release Rule
+
+PRs into `main` are treated as release PRs and must include:
+
+- `README.md` updates for user-facing package/API changes
+- `CHANGELOG.md` release notes under `## [1.2.<PR_NUMBER>] - YYYY-MM-DD`
+- NuGet package staging in `artifacts/nuget` (ignored folder) before publish
+
 ## Project Structure
 
 ```text


### PR DESCRIPTION
# Summary

Describe what changed and why.

# Validation

- [ ] `dotnet build --configuration Release`
- [ ] `dotnet test --configuration Release`

# Release Checklist (Required for PRs into `main`)

- [ ] Updated `README.md` with user-facing package/API changes
- [ ] Added release notes in `CHANGELOG.md` under `## [1.2.<PR_NUMBER>] - YYYY-MM-DD`
- [ ] Verified NuGet publish workflow can pack all required packages (`Sharc`, `Sharc.Core`, `Sharc.Query`, `Sharc.Crypto`, `Sharc.Graph.Surface`, `Sharc.Graph`, `Sharc.Vector`, `Sharc.Arc`)
