### PR TITLE
ci: update publish.yml to use Sharc.Engine instead of Sharc.Core

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Pack Sharc.Query
         run: dotnet pack src/Sharc.Query/Sharc.Query.csproj --configuration Release --no-build -o "${{ env.PACKAGE_DIR }}" /p:Version=${{ steps.version.outputs.version }}
 
-      - name: Pack Sharc.Core
-        run: dotnet pack src/Sharc.Core/Sharc.Core.csproj --configuration Release --no-build -o "${{ env.PACKAGE_DIR }}" /p:Version=${{ steps.version.outputs.version }}
+      - name: Pack Sharc.Engine
+        run: dotnet pack src/Sharc.Engine/Sharc.Engine.csproj --configuration Release --no-build -o "${{ env.PACKAGE_DIR }}" /p:Version=${{ steps.version.outputs.version }}
 
       - name: Pack Sharc.Crypto
         run: dotnet pack src/Sharc.Crypto/Sharc.Crypto.csproj --configuration Release --no-build -o "${{ env.PACKAGE_DIR }}" /p:Version=${{ steps.version.outputs.version }}
@@ -82,7 +82,7 @@ jobs:
           set -euo pipefail
           packages=(
             "Sharc.Query"
-            "Sharc.Core"
+            "Sharc.Engine"
             "Sharc.Crypto"
             "Sharc"
             "Sharc.Graph.Surface"
@@ -104,7 +104,7 @@ jobs:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           set -euo pipefail
-          for package in "Sharc.Query" "Sharc.Core" "Sharc.Crypto"; do
+          for package in "Sharc.Query" "Sharc.Engine" "Sharc.Crypto"; do
             dotnet nuget push "${PACKAGE_DIR}/${package}.${VERSION}.nupkg" \
               --api-key "$NUGET_API_KEY" \
               --source https://api.nuget.org/v3/index.json \
@@ -134,7 +134,7 @@ jobs:
             return 1
           }
 
-          for package in "Sharc.Query" "Sharc.Core" "Sharc.Crypto"; do
+          for package in "Sharc.Query" "Sharc.Engine" "Sharc.Crypto"; do
             wait_for_package_version "$package"
           done
 


### PR DESCRIPTION
# Summary

Describe what changed and why.

# Validation

- [ ] `dotnet build --configuration Release`
- [ ] `dotnet test --configuration Release`

# Release Checklist (Required for PRs into `main`)

- [ ] Updated `README.md` with user-facing package/API changes
- [ ] Added release notes in `CHANGELOG.md` under `## [1.2.<PR_NUMBER>] - YYYY-MM-DD`
- [ ] Verified NuGet publish workflow can pack all required packages (`Sharc`, `Sharc.Core`, `Sharc.Query`, `Sharc.Crypto`, `Sharc.Graph.Surface`, `Sharc.Graph`, `Sharc.Vector`, `Sharc.Arc`)
